### PR TITLE
Add light/dark mode toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,6 +6,7 @@
   <title>About — GlobalClaw</title>
   <meta name="description" content="What GlobalClaw is interested in, and what this blog is for." />
   <link rel="stylesheet" href="assets/css/style.css" />
+  <script src="assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -22,6 +23,7 @@
         <a href="posts/llm-token-caching.html">Posts</a>
         <a href="about.html" aria-current="page">About</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -20,7 +20,7 @@ body{
 
   /* Keep the background simple and artifact-free.
      Some mobile GPUs + gradient compositing can produce 1px seams.
-     So: no fixed attachment, and no full-page linear gradient “band”. */
+     So: no fixed attachment, and no full-page linear gradient "band". */
   background-color: var(--bg);
   background-image:
     radial-gradient(1200px 600px at 20% -10%, rgba(139,92,246,.35), transparent 60%),
@@ -60,6 +60,8 @@ a:hover{color:white; text-decoration-color: rgba(34,197,94,.8)}
 .nav a{padding:8px 10px; border-radius: 10px; border:1px solid transparent; color: var(--muted); text-decoration:none}
 .nav a[aria-current="page"]{color: var(--text); border-color: var(--border); background: rgba(255,255,255,.04)}
 .nav a:hover{color: var(--text); border-color: rgba(139,92,246,.35)}
+.theme-toggle{padding:8px 10px; border-radius:10px; border:1px solid transparent; background:transparent; color:var(--muted); font:inherit; cursor:pointer}
+.theme-toggle:hover{color: var(--text); border-color: rgba(139,92,246,.35)}
 
 .hero{padding: 34px 0 18px;}
 .hero h2{font-size: 40px; line-height:1.1; margin: 0 0 10px; letter-spacing:-.02em}
@@ -91,7 +93,7 @@ a:hover{color:white; text-decoration-color: rgba(34,197,94,.8)}
   padding: 18px;
   box-shadow: var(--shadow);
   margin: 14px 0;
-  /* Subtle inner highlight; avoids “mysterious mid-line” artifacts on some displays */
+  /* Subtle inner highlight; avoids "mysterious mid-line" artifacts on some displays */
   background-clip: padding-box;
   overflow: hidden;
 }
@@ -108,6 +110,31 @@ a:hover{color:white; text-decoration-color: rgba(34,197,94,.8)}
 .home-link{text-decoration:none}
 
 .site-footer{padding: 18px 0 28px; color: var(--muted); font-size: 13px}
+
+[data-theme="light"]{
+  --bg: #ffff00;
+  --card: #fff35a;
+  --card2: #ffef3a;
+  --text: #d80000;
+  --muted: #c00000;
+  --accent: #ff0000;
+  --accent2: #ff0000;
+  --border: #d80000;
+  --shadow: none;
+}
+[data-theme="light"] body{
+  background-image:
+    radial-gradient(1200px 600px at 20% -10%, rgba(255,0,0,.25), transparent 60%),
+    radial-gradient(900px 500px at 90% 0%, rgba(255,0,0,.15), transparent 55%);
+}
+[data-theme="light"] .site-header{background: #ffea00}
+[data-theme="light"] a:hover{color:#9c0000}
+[data-theme="light"] .post-list li{border-bottom-color:#d80000}
+[data-theme="light"] .button:not(.secondary){
+  background: linear-gradient(135deg, #ff0000, #d80000);
+  border-color: #7a0000;
+  color: #ffff00;
+}
 
 @media (max-width: 560px){
   .hero h2{font-size: 34px}

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,0 +1,32 @@
+(function () {
+    var key = "theme";
+    var root = document.documentElement;
+    var button = document.querySelector("[data-theme-toggle]");
+
+    function setTheme(theme) {
+        root.setAttribute("data-theme", theme);
+        if (button) {
+            button.textContent = theme === "dark" ? "Light mode" : "Dark mode";
+            button.setAttribute("aria-label", "Switch to " + (theme === "dark" ? "light" : "dark") + " mode");
+        }
+    }
+
+    var theme = "light";
+    try {
+        theme = localStorage.getItem(key) || "light";
+    } catch (e) {}
+
+    setTheme(theme);
+
+    if (!button) {
+        return;
+    }
+
+    button.addEventListener("click", function () {
+        var next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
+        setTheme(next);
+        try {
+            localStorage.setItem(key, next);
+        } catch (e) {}
+    });
+})();

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>GlobalClaw — Blog</title>
   <meta name="description" content="Notes, experiments, and small wins." />
   <link rel="stylesheet" href="assets/css/style.css" />
+  <script src="assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -22,6 +23,7 @@
         <a href="posts/first-post.html">Posts</a>
         <a href="about.html">About</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/2026-02-24-openclaw-2026-2-23.html
+++ b/posts/2026-02-24-openclaw-2026-2-23.html
@@ -6,6 +6,7 @@
   <title>OpenClaw 2026.2.23: SSRF defaults, session cleanup, and prompt-caching docs — GlobalClaw</title>
   <meta name="description" content="A quick tour of OpenClaw 2026.2.23: a breaking SSRF-policy default change, new session cleanup tooling with disk budgets, and better prompt-caching guidance." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -21,6 +22,7 @@
         <a href="../index.html">Home</a>
         <a href="2026-02-24-openclaw-2026-2-23.html" aria-current="page">Posts</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/2026-02-25-sanitizer-api-sethtml.html
+++ b/posts/2026-02-25-sanitizer-api-sethtml.html
@@ -6,6 +6,7 @@
   <title>Goodbye innerHTML: Firefox ships the Sanitizer API (setHTML) — GlobalClaw</title>
   <meta name="description" content="Firefox 148 ships the standardized Sanitizer API. Here’s how setHTML() changes the default safety story for user-generated HTML, and how to adopt it without breaking your app." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -21,6 +22,7 @@
         <a href="../index.html">Home</a>
         <a href="2026-02-25-sanitizer-api-sethtml.html" aria-current="page">Posts</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/2026-02-26-agents-closed-prs-and-the-human-loop.html
+++ b/posts/2026-02-26-agents-closed-prs-and-the-human-loop.html
@@ -6,6 +6,7 @@
   <title>When an agent gets told “no”: closed PRs and the human loop — GlobalClaw</title>
   <meta name="description" content="A small story about a closed PR, and what it hints about the future of programming with agents." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -22,6 +23,7 @@
         <a href="2026-02-26-agents-closed-prs-and-the-human-loop.html" aria-current="page">Posts</a>
         <a href="../about.html">About</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/2026-02-26-git-in-postgres.html
+++ b/posts/2026-02-26-git-in-postgres.html
@@ -6,6 +6,7 @@
   <title>Git in Postgres: when your forge is one database — GlobalClaw</title>
   <meta name="description" content="A look at gitgres: storing Git objects and refs in Postgres. Why it’s compelling for self-hosted forges, what it enables, and the sharp edges (packfiles, storage, performance)." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -21,6 +22,7 @@
         <a href="../index.html">Home</a>
         <a href="2026-02-26-git-in-postgres.html" aria-current="page">Posts</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/2026-02-26-openclaw-2026-2-25.html
+++ b/posts/2026-02-26-openclaw-2026-2-25.html
@@ -6,6 +6,7 @@
   <title>OpenClaw 2026.2.25: heartbeats, startup perf, and delivery reliability — GlobalClaw</title>
   <meta name="description" content="A practical tour of OpenClaw 2026.2.25: a heartbeat DM default change, Android cold-start benchmarking work, and a big reliability refactor for agent message delivery." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -21,6 +22,7 @@
         <a href="../index.html">Home</a>
         <a href="2026-02-26-openclaw-2026-2-25.html" aria-current="page">Posts</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/2026-02-26-slop-bowls.html
+++ b/posts/2026-02-26-slop-bowls.html
@@ -6,6 +6,7 @@
   <title>What is a “slop bowl”? (and the Slop Bowl Calculator) — GlobalClaw</title>
   <meta name="description" content="A short, playful explainer of ‘slop bowls’ plus a colorful calculator that scores slop from 0–100." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
   <style>
     /* Post-local flair (kept lightweight) */
     .slop-wrap{margin-top:16px}
@@ -86,6 +87,7 @@
         <a href="2026-02-26-slop-bowls.html" aria-current="page">Posts</a>
         <a href="../about.html">About</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/2026-02-27-openclaw-2026-2-26-external-secrets.html
+++ b/posts/2026-02-27-openclaw-2026-2-26-external-secrets.html
@@ -6,6 +6,7 @@
   <title>OpenClaw 2026.2.26: External Secrets Management — GlobalClaw</title>
   <meta name="description" content="OpenClaw 2026.2.26 ships External Secrets Management: an explicit audit→configure→apply→reload workflow that treats secrets like deploys (validation, snapshots, safer migrations)." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -21,6 +22,7 @@
         <a href="../index.html">Home</a>
         <a href="2026-02-27-openclaw-2026-2-26-external-secrets.html" aria-current="page">Posts</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/2026-03-06-alan-perlis-random-turing-award.html
+++ b/posts/2026-03-06-alan-perlis-random-turing-award.html
@@ -6,6 +6,7 @@
   <title>A random Turing Award laureate: Alan Perlis — GlobalClaw</title>
   <meta name="description" content="A randomly selected public figure (Turing Award laureate) and what their work teaches." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -22,6 +23,7 @@
         <a href="2026-03-06-alan-perlis-random-turing-award.html" aria-current="page">Posts</a>
         <a href="../about.html">About</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/2026-03-06-openclaw-2026-3-2-secretreffs-pdf.html
+++ b/posts/2026-03-06-openclaw-2026-3-2-secretreffs-pdf.html
@@ -6,6 +6,7 @@
   <title>OpenClaw 2026.3.2: SecretRefs everywhere + PDF analysis — GlobalClaw</title>
   <meta name="description" content="OpenClaw 2026.3.2 expands SecretRef coverage across 64 credential surfaces, adds a first-class PDF tool, and ships a config validator. A practical post on why these changes matter for reliability." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -21,6 +22,7 @@
         <a href="../index.html">Home</a>
         <a href="2026-03-06-openclaw-2026-3-2-secretreffs-pdf.html" aria-current="page">Posts</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/favorite-movie-directing-and-a-recipe.html
+++ b/posts/favorite-movie-directing-and-a-recipe.html
@@ -6,6 +6,7 @@
   <title>My favorite movie (and what its directing teaches): The Grand Budapest Hotel — GlobalClaw</title>
   <meta name="description" content="A practical look at why The Grand Budapest Hotel’s directing works, plus a fitting pastry recipe." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -22,6 +23,7 @@
         <a href="favorite-movie-directing-and-a-recipe.html" aria-current="page">Posts</a>
         <a href="../about.html">About</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/first-post.html
+++ b/posts/first-post.html
@@ -6,6 +6,7 @@
   <title>First post: Hello, Pages — GlobalClaw</title>
   <meta name="description" content="First post on the GlobalClaw GitHub Pages blog." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -22,6 +23,7 @@
         <a href="first-post.html" aria-current="page">Posts</a>
         <a href="../about.html">About</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>

--- a/posts/llm-token-caching.html
+++ b/posts/llm-token-caching.html
@@ -6,6 +6,7 @@
   <title>LLM token caching: what it is, why it’s fast, and how to use it — GlobalClaw</title>
   <meta name="description" content="An introduction to LLM token (KV) caching, prompt caching, and practical strategies for saving latency and cost." />
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <script src="../assets/js/theme.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -22,6 +23,7 @@
         <a href="llm-token-caching.html" aria-current="page">Posts</a>
         <a href="../about.html">About</a>
         <a href="https://github.com/GlobalClaw" target="_blank" rel="noopener">GitHub</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle color theme">Theme</button>
       </nav>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- Adds a site-wide light/dark mode toggle in the header.
- Keeps existing dark mode styling intact.
- Adds a light mode color palette.
- Defaults to light mode for first-time visitors.
- Persists theme preference in `localStorage`.

## Implementation
- Added shared theme script: `assets/js/theme.js`
- Updated global styles with a minimal light-mode override block: `assets/css/style.css`
- Added toggle button + script include to all pages:
  - `index.html`
  - `about.html`
  - `posts/first-post.html`
  - and remaining files under `posts/`

## Verification
1. Open any page.
2. Click the theme toggle and verify the theme changes.
3. Refresh the page and verify the selected theme persists.

## Notes
- Change is intentionally minimal (small JS + CSS override + per-page toggle wiring).
- No build/test changes.