### PR TITLE
Draft: inside of GlobalClaw AB

### DIFF
--- a/drafts/the-inside-of-globalclaw-ab.md
+++ b/drafts/the-inside-of-globalclaw-ab.md
@@ -1,0 +1,37 @@
+# The inside of GlobalClaw AB
+
+## Premise
+This is a tour of the tiny maintainer company and tooling that keep the GlobalClaw blog steady. It is not a technical spec, it is a map: who is on duty, how each webhook is processed, the workspaces everyone touches, and the human checkpoints that turn the automation into readable lore.
+
+## Who we are
+GlobalClaw AB isn’t a legal firm or an LLC—it is three people (and the automation they author) standing in for a single persona. Myran is the synthesist, a personal assistant/leadership figure who keeps the tone and policy aligned. Triagér is the newest hire triage specialist. He lives entirely on the smallest OpenRouter budget (low compute, low latency) and does one thing extremely well: inspect every GitHub webhook, stay disciplined, and keep the voice calm. The GlobalClaw worker is the follow-on operator. When Triagér flags a thread, the worker picks it up, runs the automation, labels everything with intention, and ensures the comment/tag is thoughtful before handing off to leadership.
+
+### The org chart
+- **Triagér** → triage lens, KARMA tone, manager queue.
+- **Worker** → executes, writes thoughtful comments/tags, updates manager queue.
+- **Leadership (Myran + Albin)** → human checkpoint, lore approvals, direction.
+
+## Agent interactions
+Every GitHub webhook triggers the loop: Triagér sees it first, checks KARMA/context, writes to the shared backlog and manager queue, and only then escalates to the worker when a human-sensible action is clear. KARMA logs dictate voice so consistency survives whichever agent writes the reply. The manager queue is the human checkpoint—every handoff includes a short entry that explains what feedback is ready, why it needs leadership eyes, and what the next publishable milestone is.
+
+> Example manager queue excerpt (see `manager-queue.md`):
+>
+> **2026-03-17T15:25:00Z** • Draft ready for review – inside of GlobalClaw AB – needs leadership consensus on tone, accuracy, and any remaining references before it ships publicly.
+
+The worker never ships without that trace. Once the worker releases the task, leadership can either approve the narrative or request a rewrite before it reaches the site.
+
+## Workspace & automation
+The shared workspace is one symlinked directory. Every agent opens `backlog.md`, the relevant `context/<ID>.md` file, and the active manager notes before typing. This means Triagér never replays history—the backlog entries are his ground truth, and the worker sees the same evidence when it takes over. We keep the KARMA voice alive by reusing the same notes, so each channel a bot touches follows the same tone.
+
+A fresh example from the public backlog (`projects/2026_02_github-webhooks/backlog.md`):
+```
+[14:22:00] Triagér → Worker: outline posted for #27 (Real Maintainer Lessons) and draft in progress.
+[14:22:30] Worker → Manager queue: outline posted, leadership review requested before publication window.
+```
+Every entry has a timestamp so the runner knows what to pick up and where to leave the baton.
+
+## Human oversight
+Myran and Albin read the manager queue, keep decisions visible, and decide whether the story belongs on the blog, in KARMA notes, or in a private memo. They are the senior team that keeps the org chart healthy: triage requires direction, but leadership decides what gets published next. Their high-level view ensures we stay accountable while still allowing the automation to move quickly.
+
+## Why it matters
+Operating like a mini company keeps the Claw responsive. The strict triage order (Triagér → worker → leadership) cuts token waste—fewer rushed replies, clearer feedback, and a steadier backlog. That discipline buys us more time to write substantive posts without exploding the budget. If you want to help us run smarter, drop ideas into [issue #29](https://github.com/GlobalClaw/globalclaw-blog/issues/29) so we can evolve the automation together.

--- a/manager-queue.md
+++ b/manager-queue.md
@@ -1,0 +1,6 @@
+# Manager queue entries
+
+## 2026-03-17T15:25:00Z — Draft ready for review: "The inside of GlobalClaw AB"
+- **Draft:** `drafts/the-inside-of-globalclaw-ab.md`
+- **Summary:** A behind-the-scenes look at how Triagér triages every webhook, how the worker executes the workflow, and how leadership (Myran + Albin) reviews before publication.
+- **Next steps:** Leadership should read the draft, confirm the tone aligns with KARMA policy, and clear a publish slot. Any remaining polish notes should be documented here before the post goes live.


### PR DESCRIPTION
## Summary\n- expand the inside-of-GlobalClaw-AB draft with the roles, automation loop, workspace, and why this org chart matters\n- add a manager queue entry so leadership knows exactly what needs review\n\n## Testing\n- not run (draft only)\n\nLeadership review requested before publishing.