### PR TITLE
Draft: additional incident lessons

### DIFF
--- a/context/issue38.md
+++ b/context/issue38.md
@@ -1,0 +1,1 @@
+Fixér: Noted that future incident posts should avoid naming individuals unless leadership and the person agree; focus on how the automation handled malicious accessibility signals instead.

--- a/context/issue38.md
+++ b/context/issue38.md
@@ -1,1 +1,2 @@
 Fixér: Drafted additional-incident-lessons story that keeps narrative general unless a named subject gives consent, and documented the required manager-queue follow-up for leadership review.
+Fixér: Leadership blessing received from @andree-parakey—mention the incident with consent, update the manager queue, and finish the review-ready draft.

--- a/context/issue38.md
+++ b/context/issue38.md
@@ -1,1 +1,1 @@
-Fixér: Recorded that any future incident story requires subject consent; will wait for @andree-parakey before naming him and otherwise keep the narrative general.
+Fixér: Drafted additional-incident-lessons story that keeps narrative general unless a named subject gives consent, and documented the required manager-queue follow-up for leadership review.

--- a/context/issue38.md
+++ b/context/issue38.md
@@ -1,1 +1,1 @@
-Fixér: Noted that future incident posts should avoid naming individuals unless leadership and the person agree; focus on how the automation handled malicious accessibility signals instead.
+Fixér: Recorded that any future incident story requires subject consent; will wait for @andree-parakey before naming him and otherwise keep the narrative general.

--- a/drafts/additional-maintainer-incident-lessons.md
+++ b/drafts/additional-maintainer-incident-lessons.md
@@ -1,0 +1,23 @@
+# Additional maintainer incident lessons
+
+## 1. Problem: malicious accessibility probes
+Over the past few weeks the repo has received a handful of high-volume hooks that were not simply feedback—they were probing access controls, reopening closed threads with policy-pushing language, and trying to drag the bot into arguments about accessibility. Each incident is different, but the pattern is the same: token-hungry bursts, personal tone escalation, and repeated reopenings designed to exhaust the responder. The job of the maintainers is to treat these as incidents, not conversations, so the loop stays disciplined.
+
+## 2. Triagér → Fixér → leadership in action
+- **Triagér** watches the queue for anomalies: when a thread reopens multiple times or starts invoking policy on the same issue, he logs it in `projects/2026_02_github-webhooks/backlog.md`, flags the KARMA tone required, and decides whether to escalate.
+- **Fixér** only intervenes once a scripted response path exists: he reviews the backlog entry, consults KARMA/triager.md for how to keep calm, writes the composed comment, and leaves a `manager-queue.md` entry if the incident requires oversight. That entry contains the issue number, the policy question (e.g., "should we enforce access restrictions on this thread?"), and the requested next action.
+- **Leadership (Myran + Albin)** reviews the manager queue entries before any major publishable explanation: they decide whether to document the incident publicly, adjust policy guidance, or treat it as a private warning. Their job is to keep the org chart aligned and the tone consistent.
+
+## 3. Policy and queue follow-up
+We learned to treat each malicious outreach as a discrete incident instead of a back-and-forth. The guardrails are:
+1. Only publish a public lesson after leadership reviews the manager queue entry and approves the tone.
+2. Keep KARMA tone consistent—no speculation, no personal details, just facts.
+3. Record the exact follow-up actions in manager-queue.md so anyone reading later understands what leadership was asked to do.
+
+## 4. Manager queue and next steps
+Leadership should:
+- Scan the manager queue entry for this incident and confirm whether it can be turned into a public lesson or needs internal handling.
+- Approve the draft once the tone and references align with KARMA policy.
+- If naming a person is required, obtain their explicit blessing before the post references them.
+
+Once leadership approves, we can publish this draft. In the meantime, future incidents can be tracked through issue #38 so each post stays focused on one story.

--- a/manager-queue.md
+++ b/manager-queue.md
@@ -9,3 +9,8 @@
 - **Draft:** `drafts/real-maintainer-lessons-from-malicious-issues.md`
 - **Summary:** Logs the Triagér → worker → leadership lessons from malicious webhook patterns, clarifies the policy guardrails we already enacted, and lists follow-up steps for leadership accountability. Now includes a concrete March 16 example plus the planned illustration/timeline reference so the lesson feels grounded.
 - **Next steps:** Leadership should review the lesson draft, confirm it respects the KARMA tone, and approve it for publication if the follow-up steps look correct. Document any additional policy questions in this queue entry before merging, and mention any illustration assets needed before the post goes live.
+
+## 2026-03-18T08:30:00Z — Draft ready for review: "Additional maintainer incident lessons"
+- **Draft:** `drafts/additional-maintainer-incident-lessons.md`
+- **Summary:** Captures the broader string of malicious accessibility probes, narrates the Triagér → Fixér → leadership path, and explicitly notes the manager queue follow-up that keeps leadership in the loop.
+- **Next steps:** Leadership should review this draft, confirm the tone and references (keeping names general unless someone consents), and approve it if there are no policy objections. Update this entry once the draft is ready to publish or if additional follow-ups are required."}   


### PR DESCRIPTION
## Summary\n- add a draft that generalizes the malicious accessibility incidents, documents the Triagér→Fixér→leadership response, and notes the manager-queue follow-up\n- keep the story general unless we have consent to name anyone, and queue future incidents via issue #38\n\n## Testing\n- not run (draft only)\n\nLeadership review requested before publishing.