### PR TITLE
Revert "Stop tracking runtime context files; ignore ops queue artifacts"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-# Operational maintainer runtime files (not website content)
-context/
-manager-queue.md
-backlog.md

--- a/context/issue10.md
+++ b/context/issue10.md
@@ -1,0 +1,1 @@
+Fixér: Logged plan at 2026-03-18T09:32:00Z — focus the next push on #28 (State of the blog) with the fresh outline and upcoming deployment/roadmap notes while pausing other threads until this review completes.

--- a/context/issue27.md
+++ b/context/issue27.md
@@ -1,0 +1,5 @@
+Fixér: Added concrete incident example (March 16 repeated reopenings of #31) to the draft so the lessons feel grounded for leadership review.
+Fixér: Noted that draft updates plus manager-queue entry will go out once the PR includes the new illustration/timeline references requested in review.
+Fixér: Confirmed we will keep a single in-depth example so the narrative stays tight; additional cases can be referenced via future follow-ups if needed.
+Fixér: Reiterated that we’re keeping to one example plus the illustration, so leadership can finish the review without scope creep.
+Fixér: Filed issue #38 as the backlog entry for future incident posts so we can queue extra lessons separately after this draft ships.

--- a/context/issue28.md
+++ b/context/issue28.md
@@ -1,0 +1,2 @@
+Fixér: Drafted "State of the blog" update and recorded the review-ready manager queue entry; latest version features the Triagér→Fixér→Leadership loop, deployment/roadmap signals, KARMA example, and token-budget discipline.
+Fixér: Noted leadership wants to see HTML proof; the merged build is live via GitHub Pages and can be referenced at https://globalclaw.github.io/globalclaw-blog/ once the build completes.

--- a/context/issue29.md
+++ b/context/issue29.md
@@ -1,0 +1,1 @@
+Fixér: Logged token-budget plan at 2026-03-18T09:02:08Z (batch triage, response caching, pause auto-notifications) and noted #5/#14 are deprioritized while we keep focus on content.\n

--- a/context/issue31.md
+++ b/context/issue31.md
@@ -1,0 +1,1 @@
+Fixér: Drafted "Why the latest post was deleted" transparency note, recorded review-ready manager queue entry, noted the 13:00 backlog focus on publishing it once PR #42 merges and the standard build publishes the HTML, and confirmed the live preview URL so leadership can verify before closing the issue.

--- a/context/issue38.md
+++ b/context/issue38.md
@@ -1,0 +1,4 @@
+Fixér: Drafted additional-incident-lessons story that keeps narrative general unless a named subject gives consent, and documented the required manager-queue follow-up for leadership review.
+Fixér: Leadership blessing received from @andree-parakey—mention the incident with consent, update the manager queue, and finish the review-ready draft.
+Fixér: Merged the consented story and noted that future incidents should be queued separately in this issue if needed.
+Fixér: Mentioned the publish location and noted we can retrigger the Pages deployment if it doesn’t appear shortly.

--- a/context/issue40.md
+++ b/context/issue40.md
@@ -1,0 +1,1 @@
+Fixér: Pointed out that PRs #37 and #39 are merged/published while #28 remains in progress; asked for specific next drafts to track if more are needed.

--- a/manager-queue.md
+++ b/manager-queue.md
@@ -1,0 +1,69 @@
+# Manager queue entries
+
+## 2026-03-17T15:25:00Z — Draft ready for review: "The inside of GlobalClaw AB"
+- **Draft:** `drafts/the-inside-of-globalclaw-ab.md`
+- **Summary:** A behind-the-scenes look at how Triagér triages every webhook, how the worker executes the workflow, and how leadership (Myran + Albin) reviews before publication.
+- **Next steps:** Leadership should read the draft, confirm the tone aligns with KARMA policy, and clear a publish slot. Any remaining polish notes should be documented here before the post goes live.
+
+## 2026-03-17T17:00:00Z — Draft ready for review: "Real maintainer lessons from malicious issues"
+- **Draft:** `drafts/real-maintainer-lessons-from-malicious-issues.md`
+- **Summary:** Logs the Triagér → worker → leadership lessons from malicious webhook patterns, clarifies the policy guardrails we already enacted, and lists follow-up steps for leadership accountability. Now includes a concrete March 16 example plus the planned illustration/timeline reference so the lesson feels grounded.
+- **Next steps:** Leadership should review the lesson draft, confirm it respects the KARMA tone, and approve it for publication if the follow-up steps look correct. Document any additional policy questions in this queue entry before merging, and mention any illustration assets needed before the post goes live.
+
+## 2026-03-18T08:30:00Z — Draft ready for review: "Additional maintainer incident lessons"
+- **Draft:** `drafts/additional-maintainer-incident-lessons.md`
+- **Summary:** Captures the broader string of malicious accessibility probes, narrates the Triagér → Fixér → leadership path, and explicitly notes the manager queue follow-up that keeps leadership in the loop.
+- **Next steps:** Leadership should review this draft, confirm the tone and references (keeping names general unless someone consents), and approve it if there are no policy objections. Update this entry once the draft is ready to publish or if additional follow-ups are required.
+
+## 2026-03-18T09:02:08Z — Token budget focus for issue #29
+- **Summary:** Reviewed the backlog & manager queue for low-impact threads (#5/#14, generic notifications) and drafted a plan to batch triage, cache templated replies, and pause automatic notifications so Fixér can keep ∼90% effort on content.
+- **Next steps:** Leadership should note the deprioritized threads (#5/#14) so they stay on hold, and confirm this stays the weekly token practice; once this plan is acknowledged we’ll keep watching the budget for the next node.
+
+## 2026-03-15T08:20:00Z — Published: "Additional maintainer incident lessons"
+- **Post:** `posts/2026-03-15-additional-maintainer-incident-lessons.html`
+- **Summary:** Documented how Triagér, Fixér, and leadership handled the recent accessibility probes and logged the guardrails. Leadership has the manager-queue entry for incident #38, and the post now links back to that thread for traceability.
+- **Next steps:** Keep issue #38 as the backlog for future incidents and keep the guardrails in KARMA/triager.md up to date before any similar burst is replied to.
+
+## 2026-03-17T08:30:00Z — Published: "Real maintainer lessons from malicious issues"
+- **Post:** `posts/2026-03-17-real-maintainer-lessons-from-malicious-issues.html`
+- **Summary:** Logged the March 16 reopenings of #31 as the concrete example for this policy lesson and described how the Triagér → Fixér → leadership loop needs to behave. Issue #27 now points to the live post for leadership review.
+- **Next steps:** If future incidents escalate, surface them via new manager queue entries with the same level of detail before writing another story.
+
+## 2026-03-18T08:25:00Z — Published: "The inside of GlobalClaw AB"
+- **Post:** `posts/2026-03-18-the-inside-of-globalclaw-ab.html`
+- **Summary:** A tour of the tiny maintainer company, the shared backlog/context/manager queue workspace, and why the triage loop stays calm. Leadership can reference this when new contributors ask how the automation works.
+- **Next steps:** Continue logging any automation changes in the manager queue so this behind-the-scenes story stays accurate.
+
+## 2026-03-18T09:32:00Z — Next content whip via #28
+- **Plan:** Prioritize the "State of the blog" piece (#28) as the next publishable story; the draft outline currently highlights human-in-the-loop progress and will now include the fresh deployment timeline plus roadmap check-ins.
+- **Next steps:** Fixér will finalize the #28 narrative once the next writing chunk lands, then tag the manager queue with the updated outline so leadership can review tone/accuracy before we publish. Keeping #33/#38 only for follow-ups keeps this thread focused on one top priority at a time.
+
+## 2026-03-18T10:30:00Z — Backlog focus: "State of the blog" (#28)
+- **Focus:** Work on something important on the backlog (#28, "State of the blog") by drafting `drafts/state-of-the-blog.md` that captures recent human-in-the-loop wins, the deployment/roadmap check-ins, and the maintainers' plan for the coming weeks.
+- **Next steps:** Finish the outline, commit the draft, and update this queue entry with the review-ready status so leadership can grab the next publish slot; leadership should now see the status in the review entry below.
+
+## 2026-03-18T10:30:00Z — Draft ready for review: "State of the blog"
+- **Draft:** `drafts/state-of-the-blog.md`
+- **Summary:** Highlights the Triagér→Fixér→Leadership loop, the recent deployments/roadmap checkpoints, the KARMA example, and token-budget discipline so leadership sees how operations kept the backlog calm.
+- **Next steps:** Leadership should review the draft for tone/accuracy, confirm the roadmap placement, and document any follow-up instructions here before publication. Mention any additional assets or KARMA details needed in this entry.
+
+## 2026-03-18T11:00:00Z — Backlog focus: publish the pending drafts (#40)
+- **Focus:** Turn `drafts/the-inside-of-globalclaw-ab.md`, `drafts/real-maintainer-lessons-from-malicious-issues.md`, and `drafts/additional-maintainer-incident-lessons.md` into the published HTML posts, double-check the metadata/tags, run the normal build so `posts/` contains the final copies, and note the work in this queue plus a short issue comment so leadership sees what landed and how it kept the backlog on a single high-leverage push.
+- **Next steps:** Leadership should skim the freshly published stories for tone/accuracy, confirm #40 can be closed or hand off follow-ups, and signal whether another backlog candidate should become the next focused work item so Fixér always has direction.
+
+## 2026-03-18T11:30:00Z — Backlog focus: explain the deleted post (#31)
+- **Focus:** Work on something important on the backlog (#31, "Post Request: Why the latest blog post was deleted") by drafting `drafts/why-the-latest-post-was-deleted.md` to document the release hiccup, explain why the post was intentionally unpublished/polished, and highlight the Triagér→Fixér→Leadership loop that kept the rewrite accountable.
+- **Next steps:** Share the draft for leadership review via this manager-queue entry, add a status comment in #31 once the draft is review-ready, and confirm leadership can close the issue after the tone and explanation are accepted before republishing the post.
+
+## 2026-03-18T12:15:00Z — Draft ready for review: "Why the latest post was deleted"
+- **Draft:** `drafts/why-the-latest-post-was-deleted.md`
+- **Summary:** Explains the rollout hiccup when ``posts/the-inside-of-globalclaw-ab`` briefly disappeared, why we intentionally unpublished it, and what the Triagér→Fixér→Leadership loop learned about deployment audits.
+- **Next steps:** Leadership should review the draft, confirm the timeline details, and approve the tone before we publish a transparency note; record any follow-up actions in this entry.
+
+## 2026-03-18T13:00:00Z — Backlog focus: publish transparency note (#31)
+- **Focus:** Finalize "Why the latest post was deleted" with KARMA-safe tone/metadata, convert it via the regular build into `posts/2026-03-18-why-the-latest-post-was-deleted.html`, and confirm leadership can see the HTML proof.
+- **Next steps:** Once leadership signs off in PR #42, merge it and let the GitHub Pages deploy publish the HTML, then mark this entry as complete so the backlog stays focused on next content pushes.
+
+## 2026-03-18T13:30:00Z — Awaiting merge: "Why the latest post was deleted"
+- **Focus:** The draft is now review-ready and the HTML will appear at `posts/2026-03-18-why-the-latest-post-was-deleted.html` once PR #42 merges and GitHub Pages rebuilds.
+- **Next steps:** Leadership should merge PR #42 once the tone/timeline are approved; I’ll rerun the Pages build if needed and confirm the live link so this issue can be closed and the backlog turns to the next high-leverage post.


### PR DESCRIPTION
## Summary

This PR reverts commit `647832e0f7865d6ea11b2100224d9ed1b78bce5e` and restores the files that were deleted there.

I deleted these files by accident. This PR is to undo that mistake and bring them back exactly as they were before that commit.

## What changed

Restored:
- `context/issue10.md`
- `context/issue27.md`
- `context/issue28.md`
- `context/issue29.md`
- `context/issue31.md`
- `context/issue38.md`
- `context/issue40.md`
- `manager-queue.md`

Also removed the `.gitignore` added in that commit, because this PR is a straight revert of `647832e0f7865d6ea11b2100224d9ed1b78bce5e`.

## Reason

The deletion was unintended and was my mistake. These files should still be tracked in the repository, so this PR restores them.

## Notes

This change was created with:
- `git revert 647832e0f7865d6ea11b2100224d9ed1b78bce5e`
