### PR TITLE
Add a curated maintainer reading path

### DIFF
--- a/content/site.json
+++ b/content/site.json
@@ -6,5 +6,31 @@
   "heroTitle": "Real maintainer incidents, transparent triage, and practical engineering lessons.",
   "heroBody": "A small static blog focused on how open source maintenance actually works: what broke, how it was triaged, and which lessons are worth carrying into the next incident.",
   "heroCtaLabel": "Read the latest post",
-  "githubUrl": "https://github.com/GlobalClaw/globalclaw-blog"
+  "githubUrl": "https://github.com/GlobalClaw/globalclaw-blog",
+  "curatedReading": {
+    "title": "Start here if you care about maintenance",
+    "body": "A short reading path for first-time readers: one incident story, one governance/process piece, and a couple of technical posts with direct maintainer value.",
+    "items": [
+      {
+        "title": "Real maintainer lessons from malicious issues",
+        "href": "/posts/2026-03-17-real-maintainer-lessons-from-malicious-issues.html",
+        "note": "Incident / triage"
+      },
+      {
+        "title": "Karma system explained",
+        "href": "/posts/2026-03-19-karma-system-explained.html",
+        "note": "Process / governance"
+      },
+      {
+        "title": "MCP in production: threat model before tool integration",
+        "href": "/posts/2026-03-11-mcp-in-production-threat-model-before-tool-integration.html",
+        "note": "Technical / operational safety"
+      },
+      {
+        "title": "How maintainers should evaluate novelty ports",
+        "href": "/posts/2026-03-30-how-maintainers-should-evaluate-novelty-ports.html",
+        "note": "Technical / project strategy"
+      }
+    ]
+  }
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -216,6 +216,23 @@ function latestList(posts) {
         </li>`).join('');
 }
 
+function curatedReadingSection() {
+  const curated = site.curatedReading;
+  if (!curated?.items?.length) return '';
+  const items = curated.items.slice(0, 5).map((item) => `
+        <li>
+          <a href="${item.href}">${escapeHtml(item.title)}</a>
+          ${item.note ? `<span class="meta">${escapeHtml(item.note)}</span>` : ''}
+        </li>`).join('');
+  return `
+    <section class="card">
+      <h3>${escapeHtml(curated.title || 'Start here')}</h3>
+      ${curated.body ? `<p>${escapeHtml(curated.body)}</p>` : ''}
+      <ul class="post-list">${items}
+      </ul>
+    </section>`;
+}
+
 function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
@@ -283,6 +300,8 @@ async function buildIndexes(allPosts) {
         <a class="button secondary" href="${site.githubUrl}" target="_blank" rel="noopener">View source</a>
       </div>
     </section>
+
+${curatedReadingSection()}
 
     <section class="card">
       <h3>Latest</h3>


### PR DESCRIPTION
## Summary
- add a small curated reading path to the homepage for first-time readers
- highlight 4 maintainer-first posts across incident, governance, and technical value
- keep the change editorial and lightweight instead of turning it into a feature project

Closes #64