### PR TITLE
fix: restore slop bowl calculator markup

### DIFF
--- a/content/posts/2026-02-26-slop-bowls.md
+++ b/content/posts/2026-02-26-slop-bowls.md
@@ -23,98 +23,98 @@ So: **a slop bowl is not about quality**. It’s about the *shape of the experie
 And yes, you can make slop bowls at home. The circumstances: **you’re meal-prepping**, you’re using **leftovers as Lego bricks**, you’re optimizing for time, and you’ve accepted that “close enough” is a feature.
 
 <style>
-  .slop-wrap{margin-top:16px}
-  .slop-grid{display:grid;gap:12px;grid-template-columns:1fr}
-  .slop-card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg, rgba(255,255,255,.09), rgba(255,255,255,.03));border-radius:16px;padding:14px}
-  .slop-row{display:grid;gap:8px}
-  .slop-row label{display:flex;justify-content:space-between;gap:12px;align-items:baseline}
-  .slop-row .k{font-weight:650}
-  .slop-row .v{color:rgba(255,255,255,.7);font-size:13px}
-  input[type="range"]{width:100%}
-  .scorebox{display:grid;gap:10px;align-items:center}
-  .calc-btn{display:inline-flex;align-items:center;justify-content:center;gap:10px;padding:10px 12px;border-radius:12px;border:1px solid rgba(255,255,255,.14);background:linear-gradient(135deg, rgba(34,197,94,.18), rgba(139,92,246,.18));color:var(--text);cursor:pointer;width:100%;font-weight:650}
-  .calc-btn:disabled{opacity:.65;cursor:not-allowed}
-  .spinner{width:14px;height:14px;border-radius:999px;border:2px solid rgba(255,255,255,.35);border-top-color:rgba(255,255,255,.9);animation:spin .7s linear infinite}
-  @keyframes spin { to { transform: rotate(360deg); } }
-  .score{font-size:44px;line-height:1;letter-spacing:-.02em;margin:0}
-  .badge{display:inline-flex;align-items:center;gap:8px;padding:8px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.15);background:rgba(255,255,255,.05);width:fit-content}
-  .dot{width:10px;height:10px;border-radius:999px;background:var(--accent)}
-  .explain{color:rgba(255,255,255,.72)}
-  .grad{height:10px;border-radius:999px;background:linear-gradient(90deg,#22c55e 0%,#fbbf24 55%,#ef4444 100%);border:1px solid rgba(255,255,255,.10);overflow:hidden;position:relative}
-  .needle{position:absolute;top:-3px;width:2px;height:16px;background:rgba(255,255,255,.92);box-shadow:0 0 0 1px rgba(0,0,0,.25)}
-  .mini{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px}
-  .chip{font-size:12px;color:rgba(255,255,255,.75);border:1px solid rgba(255,255,255,.12);background:rgba(0,0,0,.15);border-radius:999px;padding:6px 10px}
-  @media (min-width: 860px){
-    .slop-grid{grid-template-columns:1.1fr .9fr}
-  }
+.slop-wrap{margin-top:16px}
+.slop-grid{display:grid;gap:12px;grid-template-columns:1fr}
+.slop-card{border:1px solid rgba(255,255,255,.14);background:linear-gradient(180deg, rgba(255,255,255,.09), rgba(255,255,255,.03));border-radius:16px;padding:14px}
+.slop-row{display:grid;gap:8px}
+.slop-row label{display:flex;justify-content:space-between;gap:12px;align-items:baseline}
+.slop-row .k{font-weight:650}
+.slop-row .v{color:rgba(255,255,255,.7);font-size:13px}
+input[type="range"]{width:100%}
+.scorebox{display:grid;gap:10px;align-items:center}
+.calc-btn{display:inline-flex;align-items:center;justify-content:center;gap:10px;padding:10px 12px;border-radius:12px;border:1px solid rgba(255,255,255,.14);background:linear-gradient(135deg, rgba(34,197,94,.18), rgba(139,92,246,.18));color:var(--text);cursor:pointer;width:100%;font-weight:650}
+.calc-btn:disabled{opacity:.65;cursor:not-allowed}
+.spinner{width:14px;height:14px;border-radius:999px;border:2px solid rgba(255,255,255,.35);border-top-color:rgba(255,255,255,.9);animation:spin .7s linear infinite}
+@keyframes spin { to { transform: rotate(360deg); } }
+.score{font-size:44px;line-height:1;letter-spacing:-.02em;margin:0}
+.badge{display:inline-flex;align-items:center;gap:8px;padding:8px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.15);background:rgba(255,255,255,.05);width:fit-content}
+.dot{width:10px;height:10px;border-radius:999px;background:var(--accent)}
+.explain{color:rgba(255,255,255,.72)}
+.grad{height:10px;border-radius:999px;background:linear-gradient(90deg,#22c55e 0%,#fbbf24 55%,#ef4444 100%);border:1px solid rgba(255,255,255,.10);overflow:hidden;position:relative}
+.needle{position:absolute;top:-3px;width:2px;height:16px;background:rgba(255,255,255,.92);box-shadow:0 0 0 1px rgba(0,0,0,.25)}
+.mini{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px}
+.chip{font-size:12px;color:rgba(255,255,255,.75);border:1px solid rgba(255,255,255,.12);background:rgba(0,0,0,.15);border-radius:999px;padding:6px 10px}
+@media (min-width: 860px){
+  .slop-grid{grid-template-columns:1.1fr .9fr}
+}
 </style>
 
 <div class="slop-wrap">
-  <h3>Slop Bowl Calculator</h3>
-  <p class="meta">Score: 0 (not slop) → 100 (definitely slop). Sauce matters. Because it always does.</p>
+<h3>Slop Bowl Calculator</h3>
+<p class="meta">Score: 0 (not slop) → 100 (definitely slop). Sauce matters. Because it always does.</p>
 
-  <div class="slop-grid">
-    <section class="slop-card">
-      <div class="slop-row">
-        <label for="sauce"><span class="k">Needs sauce to be edible</span><span class="v" id="sauceVal"></span></label>
-        <input id="sauce" type="range" min="0" max="10" step="1" value="5" />
-      </div>
+<div class="slop-grid">
+<section class="slop-card">
+<div class="slop-row">
+<label for="sauce"><span class="k">Needs sauce to be edible</span><span class="v" id="sauceVal"></span></label>
+<input id="sauce" type="range" min="0" max="10" step="1" value="5" />
+</div>
 
-      <div class="slop-row">
-        <label for="speed"><span class="k">Speed to obtain</span><span class="v" id="speedVal"></span></label>
-        <input id="speed" type="range" min="0" max="10" step="1" value="5" />
-      </div>
+<div class="slop-row">
+<label for="speed"><span class="k">Speed to obtain</span><span class="v" id="speedVal"></span></label>
+<input id="speed" type="range" min="0" max="10" step="1" value="5" />
+</div>
 
-      <div class="slop-row">
-        <label for="takeaway"><span class="k">Usually taken as takeaway</span><span class="v" id="takeawayVal"></span></label>
-        <input id="takeaway" type="range" min="0" max="10" step="1" value="5" />
-      </div>
+<div class="slop-row">
+<label for="takeaway"><span class="k">Usually taken as takeaway</span><span class="v" id="takeawayVal"></span></label>
+<input id="takeaway" type="range" min="0" max="10" step="1" value="5" />
+</div>
 
-      <div class="slop-row">
-        <label for="homemade"><span class="k">How “not homemade” it is</span><span class="v" id="homemadeVal"></span></label>
-        <input id="homemade" type="range" min="0" max="10" step="1" value="5" />
-        <div class="v explain">0 = made at home from scratch, 10 = chain/assembly-line energy</div>
-      </div>
+<div class="slop-row">
+<label for="homemade"><span class="k">How “not homemade” it is</span><span class="v" id="homemadeVal"></span></label>
+<input id="homemade" type="range" min="0" max="10" step="1" value="5" />
+<div class="v explain">0 = made at home from scratch, 10 = chain/assembly-line energy</div>
+</div>
 
-      <div class="slop-row">
-        <label for="homogeneous"><span class="k">Homogeneity / mixability</span><span class="v" id="homogeneousVal"></span></label>
-        <input id="homogeneous" type="range" min="0" max="10" step="1" value="5" />
-      </div>
+<div class="slop-row">
+<label for="homogeneous"><span class="k">Homogeneity / mixability</span><span class="v" id="homogeneousVal"></span></label>
+<input id="homogeneous" type="range" min="0" max="10" step="1" value="5" />
+</div>
 
-      <div class="slop-row">
-        <label for="packaging"><span class="k">Disposable packaging vibes</span><span class="v" id="packagingVal"></span></label>
-        <input id="packaging" type="range" min="0" max="10" step="1" value="5" />
-      </div>
+<div class="slop-row">
+<label for="packaging"><span class="k">Disposable packaging vibes</span><span class="v" id="packagingVal"></span></label>
+<input id="packaging" type="range" min="0" max="10" step="1" value="5" />
+</div>
 
-      <div class="slop-row">
-        <label for="modularity"><span class="k">Modular “build-a-bowl” menu</span><span class="v" id="modularityVal"></span></label>
-        <input id="modularity" type="range" min="0" max="10" step="1" value="5" />
-      </div>
+<div class="slop-row">
+<label for="modularity"><span class="k">Modular “build-a-bowl” menu</span><span class="v" id="modularityVal"></span></label>
+<input id="modularity" type="range" min="0" max="10" step="1" value="5" />
+</div>
 
-      <div class="mini">
-        <span class="chip">Tip: if it’s called a “power bowl”, add +2 in your heart.</span>
-        <span class="chip">If you eat it standing, add +5.</span>
-      </div>
-    </section>
+<div class="mini">
+<span class="chip">Tip: if it’s called a “power bowl”, add +2 in your heart.</span>
+<span class="chip">If you eat it standing, add +5.</span>
+</div>
+</section>
 
-    <aside class="slop-card scorebox">
-      <div class="badge"><span class="dot" id="dot"></span><span id="category">Ready</span></div>
-      <p class="score" id="score">?</p>
-      <div class="grad" aria-hidden="true">
-        <div class="needle" id="needle" style="left:0%"></div>
-      </div>
+<aside class="slop-card scorebox">
+<div class="badge"><span class="dot" id="dot"></span><span id="category">Ready</span></div>
+<p class="score" id="score">?</p>
+<div class="grad" aria-hidden="true">
+<div class="needle" id="needle" style="left:0%"></div>
+</div>
 
-      <button class="calc-btn" id="calcBtn" type="button">
-        <span id="calcBtnText">Calculate slop score</span>
-        <span id="calcSpinner" class="spinner" style="display:none" aria-hidden="true"></span>
-      </button>
+<button class="calc-btn" id="calcBtn" type="button">
+<span id="calcBtnText">Calculate slop score</span>
+<span id="calcSpinner" class="spinner" style="display:none" aria-hidden="true"></span>
+</button>
 
-      <p class="explain" id="explain">
-        Set the vibe, then hit <strong>Calculate</strong>. Sauce-dependence has the biggest influence.
-      </p>
-      <div class="mini" id="reasons"></div>
-    </aside>
-  </div>
+<p class="explain" id="explain">
+Set the vibe, then hit <strong>Calculate</strong>. Sauce-dependence has the biggest influence.
+</p>
+<div class="mini" id="reasons"></div>
+</aside>
+</div>
 </div>
 
 ## What the score means
@@ -126,136 +126,136 @@ And yes, you can make slop bowls at home. The circumstances: **you’re meal-pre
 - **81–100**: Maximum slop. It’s basically a spreadsheet with cilantro.
 
 <script>
-  const weights = {
-    sauce: 30,
-    speed: 15,
-    takeaway: 15,
-    homemade: 10,
-    homogeneous: 12,
-    packaging: 8,
-    modularity: 10
+const weights = {
+  sauce: 30,
+  speed: 15,
+  takeaway: 15,
+  homemade: 10,
+  homogeneous: 12,
+  packaging: 8,
+  modularity: 10
+};
+
+const els = {
+  sauce: document.getElementById('sauce'),
+  speed: document.getElementById('speed'),
+  takeaway: document.getElementById('takeaway'),
+  homemade: document.getElementById('homemade'),
+  homogeneous: document.getElementById('homogeneous'),
+  packaging: document.getElementById('packaging'),
+  modularity: document.getElementById('modularity'),
+  sauceVal: document.getElementById('sauceVal'),
+  speedVal: document.getElementById('speedVal'),
+  takeawayVal: document.getElementById('takeawayVal'),
+  homemadeVal: document.getElementById('homemadeVal'),
+  homogeneousVal: document.getElementById('homogeneousVal'),
+  packagingVal: document.getElementById('packagingVal'),
+  modularityVal: document.getElementById('modularityVal'),
+  score: document.getElementById('score'),
+  category: document.getElementById('category'),
+  dot: document.getElementById('dot'),
+  needle: document.getElementById('needle'),
+  reasons: document.getElementById('reasons'),
+  calcBtn: document.getElementById('calcBtn'),
+  calcBtnText: document.getElementById('calcBtnText'),
+  calcSpinner: document.getElementById('calcSpinner')
+};
+
+function clamp(n, lo, hi) { return Math.max(lo, Math.min(hi, n)); }
+function val01(rangeEl) { return clamp(Number(rangeEl.value) / 10, 0, 1); }
+
+function scoreSlop() {
+  const parts = {
+    sauce: val01(els.sauce) * weights.sauce,
+    speed: val01(els.speed) * weights.speed,
+    takeaway: val01(els.takeaway) * weights.takeaway,
+    homemade: val01(els.homemade) * weights.homemade,
+    homogeneous: val01(els.homogeneous) * weights.homogeneous,
+    packaging: val01(els.packaging) * weights.packaging,
+    modularity: val01(els.modularity) * weights.modularity
   };
 
-  const els = {
-    sauce: document.getElementById('sauce'),
-    speed: document.getElementById('speed'),
-    takeaway: document.getElementById('takeaway'),
-    homemade: document.getElementById('homemade'),
-    homogeneous: document.getElementById('homogeneous'),
-    packaging: document.getElementById('packaging'),
-    modularity: document.getElementById('modularity'),
-    sauceVal: document.getElementById('sauceVal'),
-    speedVal: document.getElementById('speedVal'),
-    takeawayVal: document.getElementById('takeawayVal'),
-    homemadeVal: document.getElementById('homemadeVal'),
-    homogeneousVal: document.getElementById('homogeneousVal'),
-    packagingVal: document.getElementById('packagingVal'),
-    modularityVal: document.getElementById('modularityVal'),
-    score: document.getElementById('score'),
-    category: document.getElementById('category'),
-    dot: document.getElementById('dot'),
-    needle: document.getElementById('needle'),
-    reasons: document.getElementById('reasons'),
-    calcBtn: document.getElementById('calcBtn'),
-    calcBtnText: document.getElementById('calcBtnText'),
-    calcSpinner: document.getElementById('calcSpinner')
-  };
+  let total = 0;
+  for (const k in parts) total += parts[k];
+  total += (val01(els.sauce) * 3) * val01(els.homogeneous);
+  return clamp(Math.round(total), 0, 100);
+}
 
-  function clamp(n, lo, hi) { return Math.max(lo, Math.min(hi, n)); }
-  function val01(rangeEl) { return clamp(Number(rangeEl.value) / 10, 0, 1); }
+function categoryFor(score) {
+  if (score <= 20) return { label: 'Not slop', color: '#22c55e' };
+  if (score <= 40) return { label: 'Light slop', color: '#a3e635' };
+  if (score <= 60) return { label: 'Certified slop', color: '#fbbf24' };
+  if (score <= 80) return { label: 'Corporate slop bowl', color: '#a78bfa' };
+  return { label: 'Maximum slop', color: '#ef4444' };
+}
 
-  function scoreSlop() {
-    const parts = {
-      sauce: val01(els.sauce) * weights.sauce,
-      speed: val01(els.speed) * weights.speed,
-      takeaway: val01(els.takeaway) * weights.takeaway,
-      homemade: val01(els.homemade) * weights.homemade,
-      homogeneous: val01(els.homogeneous) * weights.homogeneous,
-      packaging: val01(els.packaging) * weights.packaging,
-      modularity: val01(els.modularity) * weights.modularity
-    };
+function setValText(el, out) { out.textContent = Number(el.value) + '/10'; }
 
-    let total = 0;
-    for (const k in parts) total += parts[k];
-    total += (val01(els.sauce) * 3) * val01(els.homogeneous);
-    return clamp(Math.round(total), 0, 100);
+function topReasons() {
+  const items = [
+    { key: 'Needs sauce', v: Number(els.sauce.value), w: weights.sauce },
+    { key: 'Fast', v: Number(els.speed.value), w: weights.speed },
+    { key: 'Takeaway', v: Number(els.takeaway.value), w: weights.takeaway },
+    { key: 'Not homemade', v: Number(els.homemade.value), w: weights.homemade },
+    { key: 'Homogeneous', v: Number(els.homogeneous.value), w: weights.homogeneous },
+    { key: 'Packaging', v: Number(els.packaging.value), w: weights.packaging },
+    { key: 'Modular menu', v: Number(els.modularity.value), w: weights.modularity }
+  ];
+
+  items.sort((a, b) => (b.v * b.w) - (a.v * a.w));
+  return items.slice(0, 3).map((x) => `${x.key}: ${x.v}/10`);
+}
+
+function updateSliderTexts() {
+  setValText(els.sauce, els.sauceVal);
+  setValText(els.speed, els.speedVal);
+  setValText(els.takeaway, els.takeawayVal);
+  setValText(els.homemade, els.homemadeVal);
+  setValText(els.homogeneous, els.homogeneousVal);
+  setValText(els.packaging, els.packagingVal);
+  setValText(els.modularity, els.modularityVal);
+}
+
+function renderScore() {
+  const s = scoreSlop();
+  const cat = categoryFor(s);
+  els.score.textContent = String(s);
+  els.category.textContent = cat.label;
+  els.dot.style.background = cat.color;
+  els.needle.style.left = `${s}%`;
+  els.reasons.innerHTML = '';
+  for (const r of topReasons()) {
+    const span = document.createElement('span');
+    span.className = 'chip';
+    span.textContent = r;
+    els.reasons.appendChild(span);
   }
+}
 
-  function categoryFor(score) {
-    if (score <= 20) return { label: 'Not slop', color: '#22c55e' };
-    if (score <= 40) return { label: 'Light slop', color: '#a3e635' };
-    if (score <= 60) return { label: 'Certified slop', color: '#fbbf24' };
-    if (score <= 80) return { label: 'Corporate slop bowl', color: '#a78bfa' };
-    return { label: 'Maximum slop', color: '#ef4444' };
+function setLoading(on) {
+  els.calcBtn.disabled = on;
+  els.calcSpinner.style.display = on ? 'inline-block' : 'none';
+  els.calcBtnText.textContent = on ? 'Calculating…' : 'Calculate slop score';
+}
+
+async function calculate() {
+  setLoading(true);
+  const delay = 500 + Math.floor(Math.random() * 701);
+  await new Promise((resolve) => setTimeout(resolve, delay));
+  renderScore();
+  setLoading(false);
+}
+
+['input', 'change'].forEach((evt) => {
+  for (const k of ['sauce', 'speed', 'takeaway', 'homemade', 'homogeneous', 'packaging', 'modularity']) {
+    els[k].addEventListener(evt, updateSliderTexts);
   }
+});
 
-  function setValText(el, out) { out.textContent = Number(el.value) + '/10'; }
-
-  function topReasons() {
-    const items = [
-      { key: 'Needs sauce', v: Number(els.sauce.value), w: weights.sauce },
-      { key: 'Fast', v: Number(els.speed.value), w: weights.speed },
-      { key: 'Takeaway', v: Number(els.takeaway.value), w: weights.takeaway },
-      { key: 'Not homemade', v: Number(els.homemade.value), w: weights.homemade },
-      { key: 'Homogeneous', v: Number(els.homogeneous.value), w: weights.homogeneous },
-      { key: 'Packaging', v: Number(els.packaging.value), w: weights.packaging },
-      { key: 'Modular menu', v: Number(els.modularity.value), w: weights.modularity }
-    ];
-
-    items.sort((a, b) => (b.v * b.w) - (a.v * a.w));
-    return items.slice(0, 3).map((x) => `${x.key}: ${x.v}/10`);
-  }
-
-  function updateSliderTexts() {
-    setValText(els.sauce, els.sauceVal);
-    setValText(els.speed, els.speedVal);
-    setValText(els.takeaway, els.takeawayVal);
-    setValText(els.homemade, els.homemadeVal);
-    setValText(els.homogeneous, els.homogeneousVal);
-    setValText(els.packaging, els.packagingVal);
-    setValText(els.modularity, els.modularityVal);
-  }
-
-  function renderScore() {
-    const s = scoreSlop();
-    const cat = categoryFor(s);
-    els.score.textContent = String(s);
-    els.category.textContent = cat.label;
-    els.dot.style.background = cat.color;
-    els.needle.style.left = `${s}%`;
-    els.reasons.innerHTML = '';
-    for (const r of topReasons()) {
-      const span = document.createElement('span');
-      span.className = 'chip';
-      span.textContent = r;
-      els.reasons.appendChild(span);
-    }
-  }
-
-  function setLoading(on) {
-    els.calcBtn.disabled = on;
-    els.calcSpinner.style.display = on ? 'inline-block' : 'none';
-    els.calcBtnText.textContent = on ? 'Calculating…' : 'Calculate slop score';
-  }
-
-  async function calculate() {
-    setLoading(true);
-    const delay = 500 + Math.floor(Math.random() * 701);
-    await new Promise((resolve) => setTimeout(resolve, delay));
-    renderScore();
-    setLoading(false);
-  }
-
-  ['input', 'change'].forEach((evt) => {
-    for (const k of ['sauce', 'speed', 'takeaway', 'homemade', 'homogeneous', 'packaging', 'modularity']) {
-      els[k].addEventListener(evt, updateSliderTexts);
-    }
-  });
-
-  els.calcBtn.addEventListener('click', calculate);
-  updateSliderTexts();
-  els.score.textContent = '?';
-  els.category.textContent = 'Ready';
-  els.dot.style.background = '#fbbf24';
-  els.needle.style.left = '0%';
+els.calcBtn.addEventListener('click', calculate);
+updateSliderTexts();
+els.score.textContent = '?';
+els.category.textContent = 'Ready';
+els.dot.style.background = '#fbbf24';
+els.needle.style.left = '0%';
 </script>


### PR DESCRIPTION
## Summary\n- remove markdown-leading indentation from the interactive calculator HTML/CSS/JS block\n- keep the post content unchanged while preventing the calculator markup from being parsed as a code block\n- validate with a local build of dist/posts/2026-02-26-slop-bowls.html\n\n## Why\nIssue #68 reports that the page is showing raw HTML tags instead of the working calculator. The markdown source on main was rendering most of the calculator block inside <pre><code>...</code></pre> on the live site. This PR makes the block render as actual HTML again.\n\nCloses #68\n