### PR TITLE
build: implement custom 404 page via markdown

### DIFF
--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -1,0 +1,13 @@
+---
+title: "Nothing here."
+description: "The page you requested could not be found."
+---
+
+The link may be stale, the page may have moved, or GitHub Pages handed you a dead end.
+
+### Try these instead:
+
+- [**Home**](/index.html) — The latest news and updates.
+- [**Posts**](/posts/) — Our full archive of notes and experiments.
+- [**About**](/about.html) — What we're building and why.
+- [**RSS Feed**](/rss.xml) — Follow along in your favorite reader.

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -333,24 +333,20 @@ async function buildAbout() {
 }
 
 async function build404() {
+  const raw = await fs.readFile(path.join(root, 'content/pages/404.md'), 'utf8');
+  const { data, body } = parseFrontmatter(raw);
   const html = shell({
-    title: `Not found — ${site.siteTitle}`,
-    description: 'The page you requested could not be found.',
-    body: `    <section class="hero">
-      <h2>Nothing here.</h2>
-      <p>The link may be stale, the page may have moved, or GitHub Pages handed you a dead end.</p>
-      <div class="cta">
-        <a class="button" href="/index.html">Back home</a>
-        <a class="button secondary" href="/posts/">Browse posts</a>
-      </div>
-    </section>
+    title: `${data.title || 'Not Found'} — ${site.siteTitle}`,
+    description: data.description || 'The page you requested could not be found.',
+    body: `    <article class="post card">
+      <header class="post-header">
+        <h2>${escapeHtml(data.title || 'Not Found')}</h2>
+      </header>
 
-${curatedReadingSection()}
+      ${marked.parse(body)}
 
-    <section class="card">
-      <h3>Try the latest post instead</h3>
-      <p>If you followed an old link, the homepage and posts index always point at the canonical set.</p>
-    </section>`
+      <p class="backlink"><a href="/index.html">← Back home</a></p>
+    </article>`
   });
   await fs.writeFile(path.join(outDir, '404.html'), html);
 }


### PR DESCRIPTION
This PR implements a custom 404 page for GitHub Pages by reading from `content/pages/404.md`. This "tightens" the implementation path as requested, making the 404 page consistent with other static pages like About. It includes clear recovery paths to Home, Posts, About, and the RSS feed. Fixes #74.