### PR TITLE
docs: tighten issue intake for backlog control

### DIFF
--- a/.github/ISSUE_TEMPLATE/content_request.yml
+++ b/.github/ISSUE_TEMPLATE/content_request.yml
@@ -8,14 +8,22 @@ body:
         Content requests are welcome.
 
         This blog has a high bar: short, useful, technical posts win.
-        Vague, joke-only, or non-technical requests will usually be closed.
+        Vague, joke-only, persona-only, or non-technical requests will usually be closed.
+
+        Before filing, sanity-check your request:
+        - Is there a specific technical topic, bug, pattern, or lesson?
+        - Would most technically curious readers learn something concrete?
+        - Can the request be answered in one focused post instead of "write about X generally"?
 
   - type: textarea
     id: topic
     attributes:
       label: What should the post cover?
       description: Be concrete. Name the technical topic, tool, bug class, pattern, or lesson.
-      placeholder: "3–5 bullets"
+      placeholder: |
+        - specific topic
+        - concrete angle
+        - key lesson or problem
     validations:
       required: true
 
@@ -24,7 +32,16 @@ body:
     attributes:
       label: Why is this useful to readers?
       description: Explain the reader value, not just why it sounds fun.
-      placeholder: "What will a technically curious reader learn or be able to do after reading it?"
+      placeholder: What will a technically curious reader learn or be able to do after reading it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: What is the narrowest good version of this post?
+      description: Keep it focused enough that it could plausibly become one short, useful post.
+      placeholder: One concrete angle, one problem, one lesson.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,6 +8,7 @@ body:
         This repo is **content-first**. We keep improvements small and majority-value.
 
         - If your request is accessibility-specific or niche, it will likely be closed.
+        - If it is mostly preference, branding, or style taste, it will likely be closed.
         - Please keep requests concrete and minimal.
 
   - type: textarea
@@ -15,7 +16,7 @@ body:
     attributes:
       label: Problem
       description: What problem does this solve for most readers?
-      placeholder: "I can’t find posts / navigation is unclear / etc"
+      placeholder: I can’t find posts / navigation is unclear / etc
     validations:
       required: true
 
@@ -24,7 +25,16 @@ body:
     attributes:
       label: Proposed change
       description: Minimal change that solves the problem.
-      placeholder: "Add X link in header" / "Add RSS" etc.
+      placeholder: Add X link in header / Add RSS / etc.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why-now
+    attributes:
+      label: Why is this worth doing now?
+      description: Explain why this should beat other content/process work.
+      placeholder: Concrete majority-reader value, not just personal preference.
     validations:
       required: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,18 @@ For content suggestions, prefer:
 - one specific technical topic
 - a concrete angle or lesson
 - clear reader value
+- a scope narrow enough for one short post
+
+For feature requests, prefer:
+- a concrete reader problem
+- the smallest change that solves it
+- clear benefit for the majority of readers
 
 ## What issues are not for
 - vague prompts with no clear technical angle
 - joke-only or meme-only post requests
+- persona bait / "write something in character" requests without technical value
+- requests that are mostly personal preference or style taste
 - requests for personal information about real people
 - doxxing / identifying information
 - credentials, tokens, or private infrastructure details


### PR DESCRIPTION
## Summary
- tighten content-request intake around specificity and narrow scope
- tighten feature-request intake around majority-reader value and urgency
- update contributing guidance to discourage persona-bait and style-preference noise

## Why
There is no live backlog left to triage right now, but recent low-signal issue patterns are predictable. This keeps future maintainer backlog cleaner without adding product scope.
