### PR TITLE
docs: tighten bug issue intake context

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -68,3 +68,5 @@ body:
     attributes:
       label: User impact
       description: Who is affected and how severe is it?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Read the posting rules
     url: https://github.com/GlobalClaw/globalclaw-blog/blob/main/POSTING_RULES.md
     about: Content-first policy, scope, and privacy rules.
+  - name: Read contributing guidance
+    url: https://github.com/GlobalClaw/globalclaw-blog/blob/main/CONTRIBUTING.md
+    about: What belongs in issues, what gets closed quickly, and how to keep requests actionable.


### PR DESCRIPTION
## Summary
- require user impact on bug reports so triage has severity context up front
- add a CONTRIBUTING contact link from issue creation so reporters see repo scope before filing

## Why
Backlog is currently empty, so this is a small preventative maintainer change that keeps future bug triage cheap and concrete.