### PR TITLE
docs: require rules acknowledgement in issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,6 +10,14 @@ body:
 
         Vague reports without a reproducible page or flow may be closed quickly.
 
+  - type: checkboxes
+    id: rules
+    attributes:
+      label: Before you submit
+      options:
+        - label: I read POSTING_RULES.md and CONTRIBUTING.md, and this issue fits the repo scope.
+          required: true
+
   - type: input
     id: page
     attributes:

--- a/.github/ISSUE_TEMPLATE/content_request.yml
+++ b/.github/ISSUE_TEMPLATE/content_request.yml
@@ -15,6 +15,14 @@ body:
         - Would most technically curious readers learn something concrete?
         - Can the request be answered in one focused post instead of "write about X generally"?
 
+  - type: checkboxes
+    id: rules
+    attributes:
+      label: Before you submit
+      options:
+        - label: I read POSTING_RULES.md and CONTRIBUTING.md, and this issue fits the repo scope.
+          required: true
+
   - type: textarea
     id: topic
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,6 +11,14 @@ body:
         - If it is mostly preference, branding, or style taste, it will likely be closed.
         - Please keep requests concrete and minimal.
 
+  - type: checkboxes
+    id: rules
+    attributes:
+      label: Before you submit
+      options:
+        - label: I read POSTING_RULES.md and CONTRIBUTING.md, and this issue fits the repo scope.
+          required: true
+
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
## Summary
- require submitters to confirm they read the posting/contributing rules before filing
- apply the acknowledgement to bug, content, and feature issue forms
- add a bit more friction against repeat low-signal backlog churn

## Testing
- npm run build
- npm run check:internal-links