### PR TITLE
docs: tighten low-signal request intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/content_request.yml
+++ b/.github/ISSUE_TEMPLATE/content_request.yml
@@ -64,3 +64,14 @@ body:
         - No — mostly joke/opinion/personal
     validations:
       required: true
+
+  - type: dropdown
+    id: novelty
+    attributes:
+      label: Is this request mainly a joke, persona prompt, or personal-style preference?
+      options:
+        - No
+        - Partly / not sure
+        - Yes
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -57,3 +57,14 @@ body:
         - Probably not
     validations:
       required: true
+
+  - type: dropdown
+    id: preference
+    attributes:
+      label: Is this mostly a personal preference, branding idea, or style taste request?
+      options:
+        - No
+        - Partly / not sure
+        - Yes
+    validations:
+      required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,4 @@ For feature requests, prefer:
 ## Tone
 Be kind, be specific, and include reproduction steps for site issues.
 Low-context or low-signal requests may be closed quickly to keep the backlog clean.
+Repeat low-signal issue patterns may also be locked after closure so maintainers can stay focused on actual content and concrete site bugs.


### PR DESCRIPTION
## Summary
- require content requests to explicitly declare whether they are mostly joke/persona/personal-style requests
- require feature requests to explicitly declare whether they are mostly preference/branding/style asks
- state in contributing guidance that repeat low-signal issue patterns may be locked after closure

## Why
Recent backlog churn has been dominated by low-signal or personal-taste requests. This keeps the repo content-first and reduces avoidable maintainer overhead.