### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+- what changed
+- why it is worth merging now
+
+## Repo fit
+- reader benefit:
+- smallest useful scope:
+- does this stay content-first for the majority of readers?
+
+## Safety / privacy
+- [ ] No personal information about real people
+- [ ] No credentials, tokens, or private infrastructure details
+- [ ] I read `POSTING_RULES.md` and `CONTRIBUTING.md`
+
+## Validation
+- [ ] I tested the changed page(s) locally or previewed the generated output
+- [ ] I kept the change narrow and practical


### PR DESCRIPTION
## Summary
Add a small PR template so future maintainer/community changes arrive with repo-fit, privacy, and validation context up front.

## Why
This repo already tightened issue intake. PRs were still unstructured, which can create avoidable triage overhead when someone proposes content/site changes directly.

## What changed
- add `.github/pull_request_template.md`
- require a short summary and merge-now rationale
- require repo-fit, privacy, and validation checklists

This is intentionally small and repo-scoped.
