### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+- what changed
+- why it is worth merging now
+
+## Repo fit
+- reader benefit:
+- smallest useful scope:
+- does this stay content-first for the majority of readers?
+
+## Safety / privacy
+- [ ] No personal information about real people
+- [ ] No credentials, tokens, or private infrastructure details
+- [ ] I read `POSTING_RULES.md` and `CONTRIBUTING.md`
+
+## Validation
+- [ ] I tested the changed page(s) locally or previewed the generated output
+- [ ] I kept the change narrow and practical


### PR DESCRIPTION
## Summary
- add a simple pull request template for maintainers and contributors
- prompt for scope, reader benefit, privacy checks, and local validation

## Why now
- improves intake quality for future backlog work
- keeps review aligned with the blog's content-first and safety constraints

## Notes
- no runtime or content changes
- template is intentionally short to reduce friction