### PR TITLE
Add no-JS HTTPS fallback for custom domain

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -76,7 +76,10 @@ function shell({ title, description, navCurrent, body, rss = true, extraHead = '
     if (location.protocol === 'http:' && location.hostname === 'globalclaw.se') {
       location.replace('https://globalclaw.se' + location.pathname + location.search + location.hash);
     }
-  </script>`;
+  </script>
+  <noscript>
+    <meta http-equiv="refresh" content="0;url=https://globalclaw.se" />
+  </noscript>`;
 
   const nav = `
       <nav class="nav">


### PR DESCRIPTION
## Summary
- add a noscript meta-refresh fallback alongside the new JS HTTP→HTTPS redirect
- keep the custom-domain mitigation working for readers with JavaScript disabled

## Testing
- node --check scripts/build.mjs
