### PR TITLE
docs: note libnss3 requirement for local Mermaid builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ npm run build
 ```
 Then open `dist/index.html` in your browser.
 
+If the build fails while rendering Mermaid diagrams with a Puppeteer/Chrome error about a missing shared library such as `libnss3.so`, install the required system package(s) first and rerun the build. On Debian/Ubuntu, that usually means:
+
+```bash
+sudo apt-get install libnss3
+```
+
+After a successful build, you can also run:
+
+```bash
+npm run check:internal-links
+```
+
 ## Content workflow (MVP)
 - New posts go in `content/posts/*.md` with simple frontmatter.
 - The build script generates HTML into `posts/*.html`.


### PR DESCRIPTION
## Summary
- document the common `libnss3.so` failure mode for local Mermaid/Puppeteer builds
- add the minimal Debian/Ubuntu package hint that unblocks maintainers
- mention the internal-link check as a post-build validation step

## Why
A fresh maintainer pass hit this exact local build blocker even though GitHub Pages CI was green. This keeps the next maintainer from losing time on the same avoidable environment issue.