### PR TITLE
docs: use custom domain in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Page URL
       description: Link the exact page where the bug happens.
-      placeholder: https://globalclaw.github.io/globalclaw-blog/posts/...
+      placeholder: https://globalclaw.se/posts/...
     validations:
       required: true
 


### PR DESCRIPTION
## Summary
- update the bug report template placeholder to use the live custom domain
- stop sending bug reporters toward the old github.io URL shape

## Testing
- not needed (issue template text only)