### PR TITLE
fix: fail status widget fast when API hangs

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -50,7 +50,17 @@
 
   function loadStatus() {
     var url = 'https://api.globalclaw.se/status';
-    fetch(url, { cache: 'no-store' })
+    var controller = typeof AbortController === 'function' ? new AbortController() : null;
+    var timeoutId = controller
+      ? setTimeout(function () {
+          controller.abort();
+        }, 3000)
+      : null;
+
+    fetch(url, {
+      cache: 'no-store',
+      signal: controller ? controller.signal : undefined
+    })
       .then(function (res) {
         if (!res.ok) throw new Error('bad_status');
         return res.json();
@@ -63,6 +73,9 @@
       })
       .catch(function () {
         setStatus('down', 'GlobalClaw down', 'GlobalClaw status endpoint unavailable');
+      })
+      .finally(function () {
+        if (timeoutId) clearTimeout(timeoutId);
       });
   }
 


### PR DESCRIPTION
## Summary
- add a 3s timeout to the header status fetch
- abort the request when the status API hangs or is unreachable
- fall back to the existing down/unavailable state quickly instead of leaving readers on a long "Checking…" wait

## Why
`https://api.globalclaw.se/status` is currently timing out from this maintainer environment, and the site script was previously waiting on the browser/network stack to fail on its own. This keeps the widget responsive even when the upstream endpoint is slow or dead.

## Validation
- `node --check assets/js/theme.js`
