### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+- what changed?
+- why now?
+
+## Checklist
+- [ ] This is a small, concrete change
+- [ ] I read `POSTING_RULES.md` and `CONTRIBUTING.md`
+- [ ] This helps the majority of readers, or fixes a real bug
+- [ ] I avoided personal/private information
+- [ ] If this changes generated site output, I included the generated files
+
+## Notes for maintainers
+Anything risky, incomplete, or worth double-checking?


### PR DESCRIPTION
Adds a small default PR template so incoming changes are more likely to be reviewable and in-scope.

Why now:
- there is no active backlog to triage right now
- this is a low-cost maintainer-side guardrail
- it nudges future PRs toward small, majority-value changes with generated output included when relevant