### PR TITLE
fix: clarify missing dist for internal link check

### DIFF
--- a/scripts/check-internal-links.mjs
+++ b/scripts/check-internal-links.mjs
@@ -47,6 +47,13 @@ function decodeHref(href) {
 }
 
 async function main() {
+  try {
+    await fs.access(distDir);
+  } catch {
+    console.error('Missing dist/ output. Run `npm run build` before `npm run check:internal-links`.');
+    process.exit(1);
+  }
+
   const allFiles = await walk(distDir);
   const htmlFiles = allFiles.filter((file) => file.endsWith('.html'));
   const htmlCache = new Map();


### PR DESCRIPTION
## Summary
- fail fast when `dist/` is missing before walking files
- tell maintainers to run `npm run build` before the internal-link check

## Validation
- `node --check scripts/check-internal-links.mjs`
- `node scripts/check-internal-links.mjs` (now exits with the new actionable message when `dist/` is absent)
