### PR TITLE
ci: scope pages concurrency per ref

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,7 +13,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- scope the Pages workflow concurrency group by ref instead of using one repo-wide `pages` bucket
- keep `cancel-in-progress` behavior for superseded runs on the same branch/PR

## Why
A single global concurrency group lets unrelated PR validations cancel each other and can also cancel an in-flight `main` deploy. Per-ref grouping keeps the fast feedback benefit without cross-run interference.
