### PR TITLE
ci: ignore blocked uuid security churn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "uuid"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"


### PR DESCRIPTION
## Summary
- add an explicit Dependabot config for this repo
- ignore `uuid` updates for now so the known blocked Mermaid transitive advisory stops generating repeat failing update runs
- keep the real upstream blocker tracked in #115 instead of letting it resurface as noisy failed automation

## Why now
`@mermaid-js/mermaid-cli` is still latest at `11.12.0`, and its dependency chain still resolves `mermaid -> uuid@^11.1.0`.
There is no in-repo package bump available yet that clears the advisory, so repeated Dependabot failures are just noise until upstream moves.

## Follow-up
When Mermaid ships a version that no longer pulls vulnerable `uuid`, remove this ignore and update the dependency chain.
