### PR TITLE
Force uuid@^14.0.0 via npm overrides (unblocks #115)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4077,16 +4077,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
   "dependencies": {
     "@mermaid-js/mermaid-cli": "^11.14.0",
     "marked": "^18.0.2"
+  },
+  "overrides": {
+    "uuid": "^14.0.0"
   }
 }


### PR DESCRIPTION
Forces `uuid` to non-vulnerable version (>=14.0.0) via npm `overrides` while waiting for @mermaid-js/mermaid-cli to update its dependency chain. Closes the repetitive Dependabot failure loop for the uuid advisory. Closes #115.