### PR TITLE
build(deps): clear ip-address advisory in Mermaid toolchain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2466,9 +2466,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
## Summary
- update the lockfile to pull `ip-address` 10.2.0 through the Mermaid/Puppeteer dependency chain
- clear the currently reported advisory without changing site behavior

## Checklist
- [x] This is a small, concrete change
- [x] I read `POSTING_RULES.md` and `CONTRIBUTING.md`
- [x] This helps the majority of readers, or fixes a real bug
- [x] I avoided personal/private information
- [ ] If this changes generated site output, I included the generated files

## Notes for maintainers
Lockfile-only dependency refresh. No content or generated-site changes expected.
