### PR TITLE
fix: keep future-dated posts out of published builds

### DIFF
--- a/scripts/build-gb.mjs
+++ b/scripts/build-gb.mjs
@@ -100,6 +100,12 @@ function sortPosts(posts) {
   return [...posts].sort((a, b) => `${b.date}${b.slug}`.localeCompare(`${a.date}${a.slug}`));
 }
 
+function currentPublishDate() {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: process.env.BLOG_TIME_ZONE || 'Europe/Stockholm'
+  }).format(new Date());
+}
+
 async function loadPosts() {
   const names = (await fs.readdir(postsDir)).filter((n) => n.endsWith('.md'));
   const loaded = [];
@@ -117,7 +123,8 @@ async function loadPosts() {
     });
   }
 
-  return sortPosts(loaded).slice(0, MAX_POSTS);
+  const today = currentPublishDate();
+  return sortPosts(loaded).filter((post) => post.date <= today).slice(0, MAX_POSTS);
 }
 
 async function main() {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -327,6 +327,17 @@ function sortPosts(posts) {
   return [...posts].sort((a, b) => `${b.date}${b.slug}`.localeCompare(`${a.date}${a.slug}`));
 }
 
+function currentPublishDate() {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: process.env.BLOG_TIME_ZONE || 'Europe/Stockholm'
+  }).format(new Date());
+}
+
+function publishedPosts(posts) {
+  const today = currentPublishDate();
+  return posts.filter((post) => post.date <= today);
+}
+
 function latestList(posts) {
   return posts.slice(0, 12).map((post) => `
         <li>
@@ -604,14 +615,16 @@ async function validateOutputs(allPosts) {
 await cleanDist();
 await copyStaticBits();
 const markdownPosts = await readMarkdownPosts();
-for (const post of markdownPosts) await buildMarkdownPost(post);
 const legacyPosts = await readLegacyPosts(new Set(markdownPosts.map((p) => p.slug)));
-await copyLegacyPosts(legacyPosts);
-await buildAbout();
 const allPosts = sortPosts([...markdownPosts, ...legacyPosts]);
+const visiblePosts = publishedPosts(allPosts);
+
+for (const post of visiblePosts.filter((post) => post.source === 'markdown')) await buildMarkdownPost(post);
+await copyLegacyPosts(visiblePosts.filter((post) => post.source === 'legacy'));
+await buildAbout();
 await build404();
-await buildIndexes(allPosts);
-await buildRss(allPosts);
-await buildSitemap(allPosts);
-await validateOutputs(allPosts);
-console.log(`Built dist/ with ${markdownPosts.length} markdown posts and ${legacyPosts.length} legacy posts.`);
+await buildIndexes(visiblePosts);
+await buildRss(visiblePosts);
+await buildSitemap(visiblePosts);
+await validateOutputs(visiblePosts);
+console.log(`Built dist/ with ${visiblePosts.length} published posts (${markdownPosts.length} markdown total, ${legacyPosts.length} legacy total).`);


### PR DESCRIPTION
## Summary
- keep future-dated posts out of the published web build
- keep future-dated posts out of the Game Boy content dataset
- use Europe/Stockholm as the default publish-date cutoff so scheduled posts do not leak early

## Why
`2026-05-07-upcoming-ai-model-release.md` was already being linked from the homepage, posts index, RSS, and sitemap on the evening of 2026-05-06.
