### PR TITLE
chore: ignore local backup artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ node_modules/
 dist/
 gb/dist/
 gb/generated/
+# Local scratch / editor backup artifacts
+*.backup
+.tmp-mermaid-*.mmd


### PR DESCRIPTION
## Summary
- ignore stray `*.backup` files created during local editing
- ignore temporary Mermaid input files used during rendering

## Why
Recent maintainer work left local backup files in the working tree. This keeps repo state clean and reduces the chance of accidental junk commits.