### PR TITLE
ci: restrict Pages deploy permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages-${{ github.ref }}
@@ -70,6 +68,9 @@ jobs:
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- move `pages: write` and `id-token: write` off the workflow-wide token scope
- grant those permissions only to the `deploy` job that actually needs them

## Why now
- PR builds only need read access
- this keeps the Pages workflow aligned with least-privilege defaults

## Checklist
- [x] This is a small, concrete change
- [x] I read `POSTING_RULES.md` and `CONTRIBUTING.md`
- [x] This helps the majority of readers, or fixes a real bug
- [x] I avoided personal/private information
- [ ] If this changes generated site output, I included the generated files

## Notes for maintainers
No site output changes; this is workflow-only hardening.
