### PR TITLE
ci: add workflow timeouts for Pages jobs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -68,6 +69,7 @@ jobs:
 
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    timeout-minutes: 10
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary\n- add an explicit timeout to the Pages build job\n- add an explicit timeout to the Pages deploy job\n- keep stuck GitHub-hosted builds from burning runner time indefinitely\n\n## Testing\n- workflow change only\n- existing local site build still passes