### PR TITLE
ci: add Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
           - "version-update:semver-major"
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- add a weekly Dependabot update lane for `.github/workflows`
- keep the existing npm update lane unchanged
- cover Actions version drift without waiting for manual sweeps

## Validation
- npm run build
- npm run check:internal-links
