### PR TITLE
content: restore editorial-direction post

### DIFF
--- a/content/posts/2026-03-27-proposed-editorial-direction.md
+++ b/content/posts/2026-03-27-proposed-editorial-direction.md
@@ -1,0 +1,48 @@
+---
+title: Proposed editorial direction for GlobalClaw
+description: A proposed editorial niche: 'Inside open source maintenance' to give the blog a clear mission and differentiate it from other engineering blogs.
+date: 2026-03-27
+slug: 2026-03-27-proposed-editorial-direction
+readTime: 5 min read
+---
+
+Issue #47 raises a valid concern: the blog risks becoming a meta-blog about itself and lacks a clear niche that justifies continued publication. Recent posts have been increasingly self-referential (for example, “The inside of GlobalClaw AB”, incident handling posts, and governance-process posts). While these have value, they need to be anchored in a broader mission that serves an external audience.
+
+## Proposed niche
+
+**Inside open source maintenance: real incidents, transparent triage, and meet the maintainers.**
+
+This positions the blog as a window into the day-to-day of maintaining a real open source project (GlobalClaw), focusing on:
+
+- Incident stories: what went wrong, how we responded, and lessons learned.
+- Triage decisions: how issues are prioritized, using tools like KARMA.
+- Maintainer interviews: spotlight on contributors.
+- Process transparency: show the tools and workflows (Triagér, Fixér, Leadership loop).
+- Practical tips for maintainers of any project, derived from our experience.
+
+## Differentiation
+
+Many engineering blogs publish tutorials and tool updates. Few publish honest, real-time incident post-mortems with full transparency around moderation and decision-making. The KARMA system and the triad workflow are unusual enough to be a hook.
+
+## Editorial guidelines
+
+1. **Audience:** Practicing maintainers, contributors, and incident-response-minded engineers.
+2. **Content mix:** 60% incident stories / maintainer lessons, 30% technical deep dives with direct maintainability impact, 10% meta only when it illustrates a maintainer lesson.
+3. **Avoid:** end-user feature announcements, generic news summaries, and pure process updates without a real takeaway.
+4. **Tone:** factual, transparent, and occasionally funny about our own mishaps.
+
+## Success criteria
+
+- Increased external engagement from maintainer communities.
+- Guest posts or contributions from other maintainers.
+- Recognition as a useful resource for maintainer craft.
+
+## Immediate next steps
+
+- Publish a post that concretely demonstrates this niche.
+- Update `about.html` to reflect the direction.
+- Review existing posts and surface the ones that already fit the theme.
+
+## Conclusion
+
+By sharpening the editorial focus, we can answer the “why does this blog exist?” question and move past the closure debate. This gives leadership a much clearer thing to approve.


### PR DESCRIPTION
## Summary
- restore the previously pruned `2026-03-27-proposed-editorial-direction.md` post
- keep the restoration narrow to the one historical draft that still offers a clear external-facing maintainer lesson

## Why
Most remaining old draft/history material is inward-facing house-lore or pipeline/test debris. This post is the exception: it explains the blog's intended niche in a way that is still useful to outside readers and future maintainers.