### PR TITLE
ci: add scheduled Pages health-check runs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Low-frequency health check so upstream dependency/toolchain drift fails before the next publish.
+    - cron: '17 3 * * 1,4'
   workflow_dispatch:
 
 permissions:
@@ -72,9 +75,11 @@ jobs:
           path: gb/dist/globalclaw-blog.gb
 
       - name: Configure Pages
+        if: github.event_name != 'schedule'
         uses: actions/configure-pages@v6
 
       - name: Upload artifact
+        if: github.event_name != 'schedule'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist


### PR DESCRIPTION
## Summary
- add a low-frequency scheduled trigger to the Pages workflow
- keep scheduled runs build+link-check only by skipping Pages artifact/config steps
- leave deploy restricted to pushes on `main`

Closes #153