### PR TITLE
ci: refresh remaining Pages action majors

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload artifact
         if: github.event_name != 'schedule'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 


### PR DESCRIPTION
## Summary
- upgrade the Pages workflow's remaining stale action majors
- move checkout from v4 to v6
- move upload-pages-artifact from v3 to v5

## Why
Recent backlog work refreshed most Pages workflow actions, but these two refs were still behind current major releases. Keeping the workflow on current supported majors reduces surprise drift and keeps future CI maintenance smaller.
