### PR TITLE
ci: retry GBDK toolchain download

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -53,7 +53,9 @@ jobs:
       - name: Setup GBDK
         if: steps.cache-gbdk.outputs.cache-hit != 'true'
         run: |
-          curl -L -o /tmp/gbdk.tar.gz "https://github.com/gbdk-2020/gbdk-2020/releases/download/${GBDK_VERSION}/gbdk-linux64.tar.gz"
+          curl --fail --show-error --silent --location \
+            --retry 3 --retry-delay 5 --retry-all-errors \
+            -o /tmp/gbdk.tar.gz "https://github.com/gbdk-2020/gbdk-2020/releases/download/${GBDK_VERSION}/gbdk-linux64.tar.gz"
           echo "${GBDK_LINUX64_SHA256}  /tmp/gbdk.tar.gz" | sha256sum -c -
           sudo mkdir -p /opt
           sudo tar -xzf /tmp/gbdk.tar.gz -C /opt


### PR DESCRIPTION
## Summary
- make the GBDK toolchain download fail fast on HTTP errors
- retry transient download failures before checksum verification
- keep the existing checksum gate unchanged

## Validation
- npm run build
- npm run check:internal-links