### PR TITLE
docs: clarify Mermaid runtime package baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ npm run build
 ```
 Then open `dist/index.html` in your browser.
 
-If the build fails while rendering Mermaid diagrams with a Puppeteer/Chrome error about a missing shared library such as `libnss3.so`, install the required system package(s) first and rerun the build. On Debian/Ubuntu, that usually means:
+If the build fails while rendering Mermaid diagrams with a Puppeteer/Chrome error about a missing shared library such as `libnss3.so`, install the required system package(s) first and rerun the build. On Debian/Ubuntu, the same runtime package set we use in CI is a good baseline:
 
 ```bash
-sudo apt-get install libnss3
+sudo apt-get install libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+  libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 \
+  libasound2t64 libpangocairo-1.0-0 libgtk-3-0
 ```
+
+If you only want the minimum first-pass fix, start with `libnss3` and rerun the build.
 
 After a successful build, you can also run:
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -137,7 +137,8 @@ function decorateMermaidRenderError(error) {
   if (stderr.includes('libnss3.so')) {
     const hint = [
       'Mermaid diagram rendering needs a local Chromium dependency that is missing on this machine: libnss3.so.',
-      'Install libnss3 (for example: sudo apt-get install libnss3) and rerun npm run build.',
+      'Install libnss3 first (for example: sudo apt-get install libnss3) and rerun npm run build.',
+      'If Chromium/Puppeteer still reports missing shared libraries after that, install the broader package set documented in README.md.',
       '',
       'Original renderer error:',
       stderr.trim()
@@ -179,7 +180,8 @@ async function assertMermaidRuntimeDependencies() {
 
   throw new Error([
     'Mermaid diagram rendering needs a local Chromium dependency before the build can proceed: libnss3.so.',
-    'Install libnss3 (for example: sudo apt-get install libnss3) and rerun npm run build.',
+    'Install libnss3 first (for example: sudo apt-get install libnss3) and rerun npm run build.',
+    'If Chromium/Puppeteer still reports missing shared libraries after that, install the broader package set documented in README.md.',
     'This preflight check runs before Mermaid rendering so clean Debian/Ubuntu hosts fail fast with an actionable hint.'
   ].join('\n'));
 }


### PR DESCRIPTION
## Summary
- document the broader Debian/Ubuntu Chromium runtime package baseline used in CI
- keep the fast-path `libnss3` fix, but point follow-up failures to the README package set
- make local Mermaid build failures less guessy for maintainers

## Validation
- `npm run build`