### PR TITLE
triage: prelabel feature requests as backlog

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an improvement to the blog/site.
-labels: ["enhancement"]
+labels: ["enhancement", "backlog"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary
- add the `backlog` label to the feature request template by default
- keep incoming feature requests aligned with the repo's documented backlog policy

## Why
README.md and POSTING_RULES.md already say feature requests should default to backlog handling. This removes a small triage mismatch at intake.