### PR TITLE
build: fail fast on future-dated posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npm run check:internal-links
 - The build script generates HTML into `posts/*.html`.
 - `about.html`, `index.html`, `posts/index.html`, and `rss.xml` are also generated.
 - Existing legacy HTML posts are still supported and get folded into the generated home/archive/RSS automatically, so we do not need to migrate the whole blog at once.
+- The build now fails fast if any post is future-dated, which helps prevent accidentally publishing speculative/scheduled content.
 
 Example frontmatter:
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -366,6 +366,11 @@ function currentPublishDate() {
   }).format(new Date());
 }
 
+function futureDatedPosts(posts) {
+  const today = currentPublishDate();
+  return posts.filter((post) => post.date > today);
+}
+
 function publishedPosts(posts) {
   const today = currentPublishDate();
   return posts.filter((post) => post.date <= today);
@@ -400,6 +405,23 @@ function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
   }
+}
+
+function assertNoFutureDatedPosts(posts) {
+  const futurePosts = futureDatedPosts(posts);
+  if (!futurePosts.length) return;
+
+  const details = futurePosts
+    .map((post) => `- ${post.date} · ${post.slug} (${post.source})`)
+    .join('\n');
+
+  throw new Error([
+    'Refusing to build with future-dated posts.',
+    'This blog treats post dates as publish dates, so future values are usually accidental or speculative.',
+    'Fix the post date or remove the post before rebuilding.',
+    '',
+    details
+  ].join('\n'));
 }
 
 async function buildMarkdownPost(post) {
@@ -682,6 +704,7 @@ await copyStaticBits();
 const markdownPosts = await readMarkdownPosts();
 const legacyPosts = await readLegacyPosts(new Set(markdownPosts.map((p) => p.slug)));
 const allPosts = sortPosts([...markdownPosts, ...legacyPosts]);
+assertNoFutureDatedPosts(allPosts);
 const visiblePosts = publishedPosts(allPosts);
 
 for (const post of visiblePosts.filter((post) => post.source === 'markdown')) await buildMarkdownPost(post);


### PR DESCRIPTION
## Summary
- fail the build when any markdown or legacy post is dated in the future
- surface the exact offending slug(s) in the error message
- document the guard in the README

## Why
Issue #167 noted that we should add a cheap publish guard so speculative/future-dated posts do not quietly slip through again. This keeps the repo aligned with the content policy and makes accidental dates obvious in CI and local builds.

Closes #167