### PR TITLE
content: depersonalize maintainer-process posts

### DIFF
--- a/content/posts/2026-03-17-real-maintainer-lessons-from-malicious-issues.md
+++ b/content/posts/2026-03-17-real-maintainer-lessons-from-malicious-issues.md
@@ -1,40 +1,38 @@
 ---
 title: Real maintainer lessons from malicious issues
-description: A step-by-step record of how the Triagér → Fixér → leadership loop handled malicious reopenings, why the policy changed, and what to do next.
+description: What maintainers should do when an issue thread becomes repetitive, adversarial, or clearly low-signal.
 date: 2026-03-17
 slug: 2026-03-17-real-maintainer-lessons-from-malicious-issues
-readTime: 8 min read
+readTime: 5 min read
 ---
-Early on the morning of March 16 a crawler kept reopening issue #31 and posting the same policy push.
-  Instead of replying to each ping, Triagér logged the burst in `projects/2026_02_github-webhooks/backlog.md`,
-  noted the KARMA tone, and handed the baton to Fixér. That single incident is the kind of data point we now
-  cite when we explain what “malicious issues” means in this repo.
+A noisy issue thread can trick maintainers into spending more energy on reaction than judgment.
 
-The key lesson is that the loop must stay calm and procedural. The automation doesn’t get to debate tone or
-  resolve a policy fight—its job is to log, contain, and pass the story to leadership so the narrative stays
-  accurate and the blog stays focused.
+The useful pattern is simple: log what happened, stop the back-and-forth, and make one clear decision about the thread. If the discussion is repetitive, adversarial, or obviously trying to exhaust reviewer attention, treat that as an operations problem rather than a debate to be won in public.
 
-## What we learned from the Triagér → Fixér → leadership loop
+## What good handling looks like
 
-- **Triagér** remains the front door: he inspects every webhook, adds KARMA context, writes the backlog entry, and marks whether Fixér needs a policy script.
-- **Fixér** takes over only when the path is clear: the worker reviews the backlog, composes a calm reply or label change, and writes a manager queue line that explains the policy question.
-- **Leadership** reads `manager-queue.md`, decides whether a public lesson should ship, and keeps the final story focused on accuracy rather than drama.
+- Record the observable behavior, not a dramatic story about intent.
+- Pause replies once the pattern is clear.
+- Apply labels that tell future maintainers what kind of thread they are looking at.
+- Decide whether the right outcome is a short final reply, a lock, or a close.
+- Keep any public explanation factual and brief.
 
-## Policy changes from the incidents
+## Policy lessons
 
-- Pause replies until the backlog entry names the pattern and the next action—that prevents reactive comment storms.
-- Every escalated thread now carries the `backlog` label plus any relevant policy tags so triage can see the context at a glance.
-- Keep KARMA tone consistent: confirm observable facts, cite references, and refuse to speculate.
-- Document the follow-up in `manager-queue.md` so any future audit can trace the exact decision and approval.
+A few habits consistently reduce damage:
 
-## Follow-up steps
+- **Contain repetition early.** If a thread is saying the same thing over and over, more replies rarely improve it.
+- **Optimize for maintainability.** Future readers need a clean decision record more than they need a blow-by-blow transcript.
+- **Separate facts from speculation.** Maintainers should describe what was posted and what action was taken, not guess at motives.
+- **Prefer calm closure.** A quiet, documented close is usually better than an escalating argument.
 
-- Leadership should review the new manager queue entry tied to issue #27 and confirm it can turn into a public lesson.
-- If leadership spells out further policy tweaks, make sure those changes land in KARMA/triager.md before the automation replies again.
-- Keep issue #29 updated with any broader observations; it is the place we stash backlog-level thinking about token budgets.
+## Practical checklist
 
-## Checklist before the loop runs again
+Before closing out a thread like this, confirm:
 
-- Verify the backlog entry includes timestamps, tone guidance, and the decision to escalate (the March 16 burst already has those details).
-- Confirm the manager queue entry makes the human decision visible so leadership can endorse or refuse the public lesson.
-- When the story goes live, link the post back to the incident so any future reader knows which reopening triggered the policy shift.
+- the issue has enough labels or context for later triage
+- the final maintainer note explains the decision in plain language
+- any broader policy lesson is written somewhere maintainers actually review
+- the team is aligned on whether similar threads should be closed faster next time
+
+The goal is not to sound tough. The goal is to keep the project governable under stress.

--- a/content/posts/2026-03-19-airdrop-maintainer-story.md
+++ b/content/posts/2026-03-19-airdrop-maintainer-story.md
@@ -1,28 +1,31 @@
 ---
-title: Airdrop thread: keep the backlog honest
-description: How Triagér, Fixér, and leadership should treat a pitchy backlog thread so the triad stays focused on maintainer lessons.
+title: Keep the backlog honest when a thread turns into a pitch
+description: A short maintainer note on separating backlog triage from marketing, hype, or investment-style pressure.
 date: 2026-03-19
 slug: 2026-03-19-airdrop-maintainer-story
 readTime: 3 min read
 ---
-## Triagér signal
+Not every open issue is really asking for product or engineering work. Some threads slowly turn into a pitch: they ask for visibility, momentum, or endorsement more than a concrete change.
 
-Triagér kept #43 on the backlog because every reply drifted toward an investment pitch instead of maintainer accountability. The tone kept circling financial consensus, it ignored the governance checklist, and Triagér logged the risk so future reviewers know why the thread stayed cold.
+When that happens, the maintainer job is to protect backlog quality.
 
-- The issue sent mixed signals—no KARMA-safe narrative, no triad timeline, and repeated pressure to keep the backlog as a marketing showroom.
-- Log notes from 2026-03-19T07:31:58Z capture the same red flags so tracking the decision stays traceable.
+## What to look for
 
-## Fixér reframing
+A thread is drifting out of bounds when it:
 
-The maintainer story instead focuses on how Triagér, Fixér, and leadership handle those pressure campaigns. We keep the language general, highlight the lack of policy clarity, and document the routing so similar threads can be handled consistently.
+- avoids a concrete problem statement
+- keeps pushing for attention instead of a scoped change
+- mixes governance, marketing, and product demands into one vague request
+- becomes hard to evaluate on technical or editorial merit
 
-- Turned the draft into a process lesson: document what was seen, why the backlog stayed firm, and how we insist on Triagér-approved governance checkpoints before publishing.
-- Reminded leadership that the remedy is either a resubmitted version with the requested context or a clear decision to close the thread.
+## What maintainers should do
 
-## Leadership call to action
+- Ask for a narrower proposal with a clear user-facing outcome.
+- Keep the issue open only if there is a real, reviewable change hiding inside it.
+- Close the thread if it stays vague or keeps trying to use the backlog as a promotional channel.
 
-We need a signal from leadership: should content like this stay open if it can’t describe triad reactions, or do we close the issue so the backlog keeps focused on hard maintainer lessons? If the thread stays eligible, ask @Falsen (or the original proposer) to resubmit with a defined process/governance narrative. Otherwise drop the matter so backlog space stays used for higher-leverage work.
+## The principle
 
-## Next steps
+Backlogs work when they describe work.
 
-The new story now lives at `posts/2026-03-19-airdrop-maintainer-story.html`. The homepage hero, posts archive, and RSS each point to this entry so readers see the triad-centered lesson first. Leadership should confirm whether the thread remains on policy, then either endorse the governance-friendly rewrite or close #43 to keep the backlog honest.
+Once a thread becomes mostly signaling, persuasion, or community theater, it stops competing fairly with real bugs, real posts, and real maintenance tasks. The right move is not to entertain it forever. The right move is to ask for clarity once, then close or defer if clarity never arrives.

--- a/content/posts/2026-03-19-why-the-latest-post-was-deleted.md
+++ b/content/posts/2026-03-19-why-the-latest-post-was-deleted.md
@@ -1,30 +1,30 @@
 ---
 title: Why the latest post was deleted
-description: A short note on a publish-time mis-sync, what the maintainers learned from it, and the release checks we now treat as mandatory.
+description: A short note on publish-time verification and why a small rollback is cheaper than a confusing public state.
 date: 2026-03-19
 slug: 2026-03-19-why-the-latest-post-was-deleted
 readTime: 4 min read
 ---
-## The hiccup
+A post briefly went live, then came back down.
 
-When “The inside of GlobalClaw AB” first landed, the generated site briefly regressed: the post disappeared, the homepage hero pointed at an older story, and RSS no longer reflected the newest entry. From the outside that looked like an accidental deletion. It was really a release-quality problem, so we pulled the post, inspected the build output, and treated the incident as a publishing lesson instead of pretending nothing happened.
+From the outside that can look chaotic. In practice it was the correct move: the generated site no longer matched the intended release state, so publication paused until the output could be checked.
 
-## What we learned
+## The lesson
 
-**First:** if a published post disappears, that is a release blocker.
+For static sites, source files are not the whole release.
 
-A static blog can feel simple right up until the generated output disagrees with the source tree. When that happens, the right move is to stop, inspect the generated files, and verify that the homepage, archive, and feed all agree on what the latest post actually is.
+A post can exist in the repository while the built site still has a broken homepage, stale archive, wrong feed entry, or missing page. When those disagree, readers experience the built output, not the commit history.
 
-**Second:** content changes need output checks, not just source checks.
+## What to verify before calling a release done
 
-It is not enough for the Markdown file to exist and look correct in git. A real publish check should confirm that the built article exists, that internal links still resolve, and that the homepage and feed both point at the intended story.
+- the article exists in the built site
+- the homepage points at the intended latest story
+- the archive includes the post in the right place
+- the feed reflects the same publication order
+- internal links still resolve after the change
 
-**Third:** a small rollback is cheaper than a confusing public state.
+## Why rollback was the right call
 
-Pulling a post for a short period is less damaging than leaving readers with a site that implies the latest story vanished for no reason. If the generated output looks wrong, revert to a known-good state, fix the pipeline or content issue, then publish again cleanly.
+A short rollback is cheaper than leaving readers in a confusing half-published state.
 
-## The rule going forward
-
-We now treat homepage, archive, and RSS verification as part of the definition of done for a release. If any of them drift from the intended latest post, we pause publication until the mismatch is explained and fixed.
-
-That is not glamorous process. It is just the kind that keeps a quiet blog from feeling haunted.
+If the output looks wrong, stop, inspect, and republish cleanly. That is not overreaction. It is basic release hygiene for content sites.

--- a/content/posts/2026-03-20-community-voting-v1-spec.md
+++ b/content/posts/2026-03-20-community-voting-v1-spec.md
@@ -1,40 +1,36 @@
 ---
 title: Community voting (v1): lightweight spec
-description: A lightweight, GitHub-native voting mechanism to give the community influence on backlog priorities while staying maintainer-controlled.
+description: A simple way to collect community interest without handing roadmap control to popularity contests.
 date: 2026-03-20
 slug: 2026-03-20-community-voting-v1-spec
-readTime: 5 min read
+readTime: 4 min read
 ---
-This post outlines a lightweight, GitHub-native voting mechanism designed to give the community a voice in backlog prioritization while keeping maintainer control. It’s a reaction-based system with weekly tallies, a high‑signal label, and a Community‑picked swimlane on the Kanban board. The maintainers retain final say and will evaluate after a 4‑week trial.
+Projects often want more user input on priorities without turning the roadmap into a referendum.
+
+A lightweight voting system can help, but only if it stays advisory.
 
 ## Goal
 
-Allow the GlobalClaw community to influence backlog prioritization without adding heavy tooling. Keep it native to GitHub and maintainer‑controlled.
+Collect a visible signal about community interest while keeping final prioritization with maintainers.
 
-## Mechanism
+## Minimal design
 
-- Use issue reactions (👍, 👎) as a proxy for votes.
-- Maintainer (Fixér) runs a weekly script that scans all open backlog issues labeled “enhancement” or “backlog” and tallies the total positive reactions.
-- Issues with at least 2 distinct positive reactions and a net positive score (thumbs‑up minus thumbs‑down) get a “high‑signal” label and move to the top of the Kanban board.
+- Use issue reactions as a low-friction interest signal.
+- Review only open issues that are already considered legitimate backlog candidates.
+- Treat net-positive reactions as one input into triage, not a binding result.
+- Surface a short list of high-interest items in periodic backlog reviews.
 
-## Rules
+## Guardrails
 
-- Only registered GitHub users can react (no anonymous votes).
-- Maintainers reserve the right to discard reactions that look like spam or orchestrated campaigns.
-- Voting window: Thursday 00:00 UTC to Sunday 23:59 UTC each week; results are processed Monday morning and logged in `manager-queue.md`.
+- Popularity should never override safety, scope, or maintenance cost.
+- Vague requests should not win just because they attract reactions.
+- Maintainers should ignore obvious brigading, spam, or campaign behavior.
+- Items that get strong support still need a concrete owner and a clear problem statement.
 
-## Output
+## Why keep it lightweight
 
-- A sorted “Top contenders” section in the next *State of the blog* post, listing the 3–5 issues with the highest net positive reactions.
-- The Kanban board will have a “Community‑picked” swimlane for those issues to make them visible.
+Heavy governance machinery is often worse than no voting at all. If the mechanism needs constant policing, dashboards, or ceremony, it burns more maintainer time than the signal is worth.
 
-## Limitations
+The best version is intentionally modest: easy to understand, easy to ignore when low-quality, and useful mainly as a tie-breaker between already-valid options.
 
-- No per‑user or per‑reaction weight; it’s purely a popularity signal to augment maintainer judgment.
-- No vote caps; a user can only react once per issue.
-
-## Evaluation
-
-After 4 weeks, the maintainers will assess whether the signal is high‑quality or if we need stricter rules (e.g., require a comment explaining the vote).
-
-*This draft was prepared for issue #14 and is published per leadership approval to trial the community voting feature.*
+That keeps community input visible without pretending that stewardship can be crowdsourced.


### PR DESCRIPTION
## Summary
- rewrite four remaining internal-process posts into public-facing maintainer guidance
- remove internal role names, internal file references, and repo-lore framing
- keep the underlying lessons while aligning the posts with POSTING_RULES.md

## Validation
- `npm run build`
- `node scripts/check-internal-links.mjs`

Build completed successfully for the site output; the existing Mermaid/Chromium shared-library warning is unrelated to these content edits.

Closes #176