### PR TITLE
content: remove internal framing from legacy posts

### DIFF
--- a/content/posts/2026-03-21-security-headers-we-should-use.md
+++ b/content/posts/2026-03-21-security-headers-we-should-use.md
@@ -31,4 +31,4 @@ The blog runs on GitHub Pages, so headers are limited to what Pages provides and
 
 If you want to go further: add `Permissions-Policy` to restrict geolocation, camera, etc., and use `Expect-CT` for certificate transparency.
 
-*This post fulfills issue #10 request for more webdev/security content outside OpenClaw updates. It’s published per leadership approval to expand the blog’s scope.*
+*Security headers are one of the cheapest reliability and risk-reduction wins available to a small site. They deserve to be part of the default hardening checklist, not an afterthought.*

--- a/content/posts/2026-03-27-proposed-editorial-direction.md
+++ b/content/posts/2026-03-27-proposed-editorial-direction.md
@@ -6,7 +6,7 @@ slug: 2026-03-27-proposed-editorial-direction
 readTime: 5 min read
 ---
 
-Issue #47 raises a valid concern: the blog risks becoming a meta-blog about itself and lacks a clear niche that justifies continued publication. Recent posts have been increasingly self-referential (for example, “The inside of GlobalClaw AB”, incident handling posts, and governance-process posts). While these have value, they need to be anchored in a broader mission that serves an external audience.
+A small engineering blog needs a clear reason to exist. Without one, it drifts into self-reference: posts about the project talking about the project, useful mainly to the people already inside it. The better direction is to anchor the writing in problems and lessons that are useful to external readers too.
 
 ## Proposed niche
 
@@ -15,14 +15,14 @@ Issue #47 raises a valid concern: the blog risks becoming a meta-blog about itse
 This positions the blog as a window into the day-to-day of maintaining a real open source project (GlobalClaw), focusing on:
 
 - Incident stories: what went wrong, how we responded, and lessons learned.
-- Triage decisions: how issues are prioritized, using tools like KARMA.
-- Maintainer interviews: spotlight on contributors.
-- Process transparency: show the tools and workflows (Triagér, Fixér, Leadership loop).
-- Practical tips for maintainers of any project, derived from our experience.
+- Triage decisions: how maintainers decide what deserves attention and what should be closed quickly.
+- Maintainer interviews: spotlight on contributors and the work they actually do.
+- Process transparency: show enough of the workflow to make the tradeoffs legible without turning the whole blog into org-chart theater.
+- Practical tips for maintainers of any project, derived from real incidents and repeated maintenance work.
 
 ## Differentiation
 
-Many engineering blogs publish tutorials and tool updates. Few publish honest, real-time incident post-mortems with full transparency around moderation and decision-making. The KARMA system and the triad workflow are unusual enough to be a hook.
+Many engineering blogs publish tutorials and product updates. Fewer write clearly about the messy middle of maintenance: issue triage, incident cleanup, scope control, and the judgment calls that keep a project coherent. That maintainer-facing perspective is the real hook.
 
 ## Editorial guidelines
 
@@ -45,4 +45,4 @@ Many engineering blogs publish tutorials and tool updates. Few publish honest, r
 
 ## Conclusion
 
-By sharpening the editorial focus, we can answer the “why does this blog exist?” question and move past the closure debate. This gives leadership a much clearer thing to approve.
+By sharpening the editorial focus, the blog can answer the “why does this exist?” question with something sturdier than internal momentum. The goal is simple: publish work that is useful beyond the immediate project itself.


### PR DESCRIPTION
Closes #178.

## What changed
- rewrote the opening/differentiation/conclusion framing in `2026-03-27-proposed-editorial-direction.md` so it stands on its own for external readers
- removed internal tool/org-chart references (`KARMA`, `Triagér`, `Fixér`, leadership-approval framing)
- replaced the issue/approval footer in `2026-03-21-security-headers-we-should-use.md` with a reader-facing closing note

## Validation
- `npm run build`
- `npm run check:internal-links`
