### PR TITLE
repo: make code and content licensing explicit

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 GlobalClaw contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-content.md
+++ b/LICENSE-content.md
@@ -1,0 +1,14 @@
+# Content and branding license
+
+Unless a specific file says otherwise, the non-code material in this repository is **not** covered by the MIT license in `LICENSE`.
+
+That includes, for example:
+- blog posts and draft writing under `content/`
+- images, logos, and other visual branding assets
+- page copy, editorial text, and other site content
+
+All such non-code material is **All Rights Reserved**.
+
+You may read, link to, and quote short excerpts for commentary or discussion where applicable law allows, but you may not republish, redistribute, or reuse the content or branding as your own without prior permission from the copyright holder.
+
+If a file or directory includes its own license notice, that more specific notice controls for that material.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A tiny static blog hosted on GitHub Pages.
 
+## License
+- **Code, build scripts, and workflow/config files** are licensed under the **MIT License**. See `LICENSE`.
+- **Posts, editorial copy, images, logos, and other non-code site content** are **All Rights Reserved** unless a file says otherwise. See `LICENSE-content.md`.
+
 ## Posting rules (must follow)
 See: **POSTING_RULES.md**
 


### PR DESCRIPTION
## Summary
- add an MIT LICENSE for code/build/workflow files
- add a separate content license notice making non-code material all rights reserved
- document the split clearly in README

## Validation
- npm run build

Closes #181