### PR TITLE
docs: add security reporting policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ For feature requests, prefer:
 - doxxing / identifying information
 - credentials, tokens, or private infrastructure details
 
+## Security and privacy reports
+If the issue is a real security/privacy problem, do **not** post exploit details publicly.
+Follow `SECURITY.md` instead.
+
 ## Tone
 Be kind, be specific, and include reproduction steps for site issues.
 Low-context or low-signal requests may be closed quickly to keep the backlog clean.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A tiny static blog hosted on GitHub Pages.
 - **Code, build scripts, and workflow/config files** are licensed under the **MIT License**. See `LICENSE`.
 - **Posts, editorial copy, images, logos, and other non-code site content** are **All Rights Reserved** unless a file says otherwise. See `LICENSE-content.md`.
 
+## Security
+See `SECURITY.md` for how to report real security/privacy bugs without dumping sensitive details into public issues.
+
 ## Posting rules (must follow)
 See: **POSTING_RULES.md**
 
@@ -20,6 +23,7 @@ There is no active GitHub Project board for this repo right now.
 
 Use issues + labels instead:
 - bugs stay open when actionable
+- security/privacy reports should follow `SECURITY.md`
 - feature/content requests default to `backlog` + close unless they are clearly in-scope and worth immediate maintainer time
 - PRs are the main vehicle for concrete work moving forward
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported versions
+This repository is small and deployed directly from the `main` branch.
+
+- `main`: supported
+- older commits / historical snapshots: unsupported
+
+## Reporting a vulnerability
+If you find a real security issue in the site, build scripts, workflow, or published content handling:
+
+1. **Do not open a public issue with exploit details.**
+2. Open a **private GitHub security advisory** for this repository if that option is available to you.
+3. If you cannot use a private advisory, open a minimal public issue that says a security problem exists **without disclosing sensitive details**.
+
+Good reports include:
+- affected file, page, or workflow
+- impact
+- reproduction steps or proof of concept
+- any suggested fix or mitigation
+
+## Out of scope
+The following are usually not treated as security reports for this repo:
+- low-value SEO suggestions
+- generic header/cookie/CSP wishlist items without a concrete exploit path
+- content disagreements or editorial/style preferences
+- requests for personal/private infrastructure details
+
+## Maintainer policy
+Security/privacy bugs with clear impact can stay open and be handled quickly.
+Low-signal or public oversharing of sensitive details may be edited, closed, or locked to protect readers and the maintainer workflow.


### PR DESCRIPTION
## Summary\n- add a SECURITY.md with a minimal disclosure path for real security/privacy bugs\n- point README backlog guidance at the security policy\n- tell contributors not to post exploit details publicly\n\n## Why\nWith no open backlog items to triage, this is practical maintainer hygiene: it gives real bugs a cleaner path while keeping public issues focused on normal site/content work.