### PR TITLE
build: fail when mermaid runtime dependencies are missing

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -226,12 +226,7 @@ async function renderMermaidBlocks(markdown, slug) {
   const matches = [...markdown.matchAll(/```mermaid\n([\s\S]*?)```/g)];
   if (!matches.length) return markdown;
 
-  try {
-    await assertMermaidRuntimeDependencies();
-  } catch (e) {
-    console.warn(`Skipping Mermaid rendering for ${slug}: ${e.message}`);
-    return markdown;
-  }
+  await assertMermaidRuntimeDependencies();
 
   let out = markdown;
   for (const match of matches) {


### PR DESCRIPTION
## Summary
- stop swallowing missing Mermaid/Chromium runtime dependency failures
- fail the build when Mermaid blocks exist but required local libs are missing
- align runtime behavior with the existing fail-fast error text

## Validation
- reproduced the reported `libnss3.so` host failure locally
- confirmed `npm run build` now exits non-zero instead of continuing with unrendered Mermaid blocks