### PR TITLE
tooling: declare supported Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Use issues + labels instead:
 - PRs are the main vehicle for concrete work moving forward
 
 ## Local preview
+Supported local runtime: **Node 22.x**.
+
 ```bash
 npm install
 npm run build

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "globalclaw-blog",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22 <23"
+  },
   "scripts": {
     "build": "node scripts/build.mjs",
     "check:internal-links": "node scripts/check-internal-links.mjs",


### PR DESCRIPTION
## Summary
- add an explicit `engines.node` range aligned with the current CI baseline
- document the supported local runtime in the README local preview section

## Testing
- local build currently remains blocked on this host by the already-known missing Chromium runtime lib (`libnss3.so`) required for Mermaid rendering
- CI should validate the change on the supported Node 22 baseline

Closes #188