### PR TITLE
content: restore editorial-direction lesson as evergreen post

### DIFF
--- a/content/posts/2026-05-15-a-technical-blog-needs-a-job.md
+++ b/content/posts/2026-05-15-a-technical-blog-needs-a-job.md
@@ -1,0 +1,91 @@
+---
+title: A technical blog needs a job, not just a publishing pipeline
+description: A simple editorial test for maintainers: define who the blog serves, what kind of lessons belong there, and what to stop publishing.
+date: 2026-05-15
+slug: 2026-05-15-a-technical-blog-needs-a-job
+readTime: 4 min read
+---
+A blog can be technically healthy and still editorially confused.
+
+That happens when maintainers solve the mechanics of publishing before they solve the question that matters more: **what is this blog for?** If the answer is fuzzy, the posts start drifting toward whatever is easiest to publish—status updates, internal chatter, vague announcements, or content that is more about the blog than useful to the reader.
+
+A technical blog needs a job.
+
+## The three questions
+
+Before publishing regularly, write down clear answers to these:
+
+### 1. Who is the reader?
+“People on the internet” is not a reader.
+
+A better answer is specific enough to exclude things. Examples:
+
+- maintainers who want practical incident lessons
+- engineers evaluating tools and trade-offs
+- contributors trying to understand a project’s decisions
+
+If you cannot name the reader, you cannot reliably decide what belongs.
+
+### 2. What kind of lesson should readers expect?
+A useful blog trains expectation.
+
+Readers should know whether a post is likely to give them:
+
+- a technical explanation
+- a maintainer decision framework
+- a postmortem with transferable lessons
+- a concise opinion grounded in real work
+
+When every post teaches a different kind of thing, the publication feels random even if each individual post is decent.
+
+### 3. What do you explicitly refuse to publish?
+This is where editorial discipline actually appears.
+
+A blog gets sharper when maintainers can say:
+
+- we do not publish half-verified news
+- we do not publish internal navel-gazing unless it teaches something reusable
+- we do not turn every issue-thread argument into a post
+- we do not keep posts whose main value is that they filled a slot
+
+A “no” list is often more important than a content calendar.
+
+## The drift pattern to watch for
+
+Many technical blogs drift in the same direction:
+
+1. the publishing pipeline gets easier
+2. cadence starts to matter
+3. empty slots appear
+4. maintainers publish whatever is nearby
+5. the blog becomes about itself
+
+That is not a tooling failure. It is an editorial one.
+
+The fix is usually simple: tighten the scope and let some days stay empty.
+
+## A practical maintainer rule
+
+Before a post goes live, ask one boring question:
+
+**Would a new reader understand why this post exists on this blog specifically?**
+
+If the answer is no, the post probably belongs somewhere else:
+
+- a commit message
+- a pull request
+- a changelog
+- an issue comment
+- a private note
+
+Not every piece of project activity deserves to become an article.
+
+## The job comes before the cadence
+
+Cadence can help a blog stay alive, but it is a bad substitute for mission.
+
+A smaller stream of clear, on-mission posts will usually outperform a busier stream of confused ones. Readers forgive infrequency much faster than they forgive blur.
+
+A blog does not need more posts.
+
+It needs a reason to exist, and the discipline to keep earning that reason.


### PR DESCRIPTION
## Summary
- revive the one old deleted draft that still had a real maintainer lesson inside it
- rewrite it into a cleaner evergreen post about editorial scope for technical blogs
- queue it for 2026-05-15 instead of publishing a second post today

## Rationale
Most of the deleted old-post pile was rightly deleted: too internal, too speculative, or too off-mission.

The exception was the old editorial-direction draft. The original version was too self-referential, but the core point was worth keeping: a technical blog needs a clear job, a clear reader, and a clear list of things it refuses to publish.

## Verification
- content review only
- local build currently blocked on this VM because Mermaid rendering needs `libnss3.so`
