### PR TITLE
security: fix remaining CodeQL alert patterns

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -269,8 +269,48 @@ function preserveRawBlocks(markdown) {
     return `\n\n${token}\n\n`;
   }
 
-  out = out.replace(/<style>[\s\S]*?<\/style>/g, stash);
-  out = out.replace(/<script>[\s\S]*?<\/script>/g, stash);
+  function stashWholeTagBlocks(input, tagName) {
+    const lower = input.toLowerCase();
+    const openNeedle = `<${tagName}`;
+    const closeNeedle = `</${tagName}`;
+    let cursor = 0;
+    let result = '';
+
+    while (cursor < input.length) {
+      const start = lower.indexOf(openNeedle, cursor);
+      if (start === -1) {
+        result += input.slice(cursor);
+        break;
+      }
+
+      const openEnd = input.indexOf('>', start);
+      if (openEnd === -1) {
+        result += input.slice(cursor);
+        break;
+      }
+
+      const closeStart = lower.indexOf(closeNeedle, openEnd + 1);
+      if (closeStart === -1) {
+        result += input.slice(cursor);
+        break;
+      }
+
+      const closeEnd = input.indexOf('>', closeStart);
+      if (closeEnd === -1) {
+        result += input.slice(cursor);
+        break;
+      }
+
+      result += input.slice(cursor, start);
+      result += stash(input.slice(start, closeEnd + 1));
+      cursor = closeEnd + 1;
+    }
+
+    return result;
+  }
+
+  out = stashWholeTagBlocks(out, 'style');
+  out = stashWholeTagBlocks(out, 'script');
 
   const slopStart = out.indexOf('<div class="slop-wrap">');
   if (slopStart !== -1) {

--- a/scripts/check-internal-links.mjs
+++ b/scripts/check-internal-links.mjs
@@ -128,6 +128,18 @@ async function validateSourceLinks(errors) {
   return sourceFiles.length;
 }
 
+async function readHtmlTarget(targetFile) {
+  try {
+    return { targetFile, html: await fs.readFile(targetFile, 'utf8') };
+  } catch (error) {
+    if (error?.code === 'EISDIR') {
+      const indexFile = path.join(targetFile, 'index.html');
+      return { targetFile: indexFile, html: await fs.readFile(indexFile, 'utf8') };
+    }
+    throw error;
+  }
+}
+
 async function main() {
   try {
     await fs.access(distDir);
@@ -168,20 +180,20 @@ async function main() {
         targetFile = path.resolve(sourceDir, normalizeFileTarget(pathPart));
       }
 
+      let targetHtml;
       try {
-        const stat = await fs.stat(targetFile);
-        if (stat.isDirectory()) {
-          targetFile = path.join(targetFile, 'index.html');
-          await fs.access(targetFile);
-        }
+        const resolved = htmlCache.has(targetFile)
+          ? { targetFile, html: htmlCache.get(targetFile) }
+          : await readHtmlTarget(targetFile);
+        targetFile = resolved.targetFile;
+        targetHtml = resolved.html;
+        htmlCache.set(targetFile, targetHtml);
       } catch {
         errors.push(`${sourceRel} -> ${rawHref} (missing file: ${path.relative(distDir, targetFile)})`);
         continue;
       }
 
       if (!rawFragment) continue;
-      const targetHtml = htmlCache.get(targetFile) ?? await fs.readFile(targetFile, 'utf8');
-      htmlCache.set(targetFile, targetHtml);
       const ids = extractIds(targetHtml);
       if (!ids.has(rawFragment)) {
         errors.push(`${sourceRel} -> ${rawHref} (missing anchor: #${rawFragment} in ${path.relative(distDir, targetFile)})`);


### PR DESCRIPTION
## Summary
- replace regex-based raw `<style>` / `<script>` block stashing with explicit tag scanning
- resolve built HTML targets by attempting the real read operation directly instead of stat/access prechecks
- keep the internal-link audit behavior the same while removing the TOCTOU pattern CodeQL flagged

## Validation
- `node --check scripts/build.mjs`
- `node --check scripts/check-internal-links.mjs`
- `npm run build` *(blocked locally on this VM by missing `libnss3.so`, which the repo already documents; relying on CI for full validation)*
