### PR TITLE
draft: Go CrossOriginProtection post

### DIFF
--- a/content/posts/2026-05-20-go-crossoriginprotection.md
+++ b/content/posts/2026-05-20-go-crossoriginprotection.md
@@ -1,0 +1,135 @@
+---
+title: Go’s CrossOriginProtection: good ambient CSRF friction, not a magic shield
+description: Go 1.25 adds net/http CrossOriginProtection. Here’s what it usefully reduces, what it does not replace, and how maintainers should roll it out without lying to themselves.
+date: 2026-05-20
+slug: 2026-05-20-go-crossoriginprotection
+readTime: ~7 min read
+---
+Go 1.25 added `net/http.CrossOriginProtection` to the standard library.
+That is genuinely useful, mostly because it makes one class of defensive hygiene easier to apply by default.
+
+The trap is obvious: as soon as a security feature lands in the stdlib, people start talking about it like it replaced judgment.
+It did not.
+
+`CrossOriginProtection` is best understood as **ambient CSRF friction**.
+It helps reject cross-site state-changing requests when the browser gives the server enough signal to tell that the request came from another site.
+That is valuable. It is also narrower than “CSRF solved.”
+
+Primary sources:
+- [Go 1.25 release notes](https://go.dev/doc/go1.25)
+- [`net/http` docs for `CrossOriginProtection`](https://pkg.go.dev/net/http#CrossOriginProtection)
+- [Go 1.25.1 / 1.24.7 security release note for CVE-2025-47910](https://groups.google.com/g/golang-announce/c/PtW9VW21NPs/m/DJhMQ-m5AQAJ)
+
+## The problem it actually reduces
+If your app uses cookie-backed sessions or other ambient credentials, the browser may automatically attach those credentials when a victim visits an attacker-controlled page that submits a request to your service.
+
+That is the old CSRF shape:
+- the victim is logged in to your app
+- the attacker gets the victim’s browser to send a request
+- the browser helpfully includes the victim’s cookies
+- your server sees an authenticated request unless you reject it
+
+The important word there is **ambient**.
+The browser is carrying auth state around on the user’s behalf.
+`CrossOriginProtection` exists to help when that ambient state reaches a handler that changes something.
+
+## What Go’s middleware checks
+The stdlib docs describe `CrossOriginProtection` as rejecting non-safe cross-origin browser requests by using request metadata like `Sec-Fetch-Site`, with `Origin` checks as a fallback.
+That is the right mental model.
+
+In practice, the useful maintainer summary is:
+- safe methods are allowed
+- state-changing requests get scrutiny
+- clearly cross-site browser requests are denied
+- same-origin requests continue through normally
+- you can explicitly trust additional origins when that is intentional
+
+That is enough to remove a lot of accidental exposure in ordinary web apps and internal tools.
+
+It is especially attractive because it lives in the stdlib and wraps a handler directly, which lowers the cost of “just add the protection” compared to pulling in another package and inventing one more house policy.
+
+## Tiny example
+This is the shape most maintainers should think in:
+
+```go
+mux := http.NewServeMux()
+mux.HandleFunc("POST /settings/email", updateEmail)
+
+cop := http.NewCrossOriginProtection()
+
+// Only if you intentionally accept state-changing requests from another origin.
+if err := cop.AddTrustedOrigin("https://admin.example.com"); err != nil {
+    log.Fatal(err)
+}
+
+srv := &http.Server{
+    Addr:    ":8080",
+    Handler: cop.Handler(mux),
+}
+```
+
+That gets you a real default: state-changing browser requests are not accepted blindly just because a cookie exists.
+
+## What it does **not** solve
+This part matters more than the API surface.
+
+### 1. It does not replace auth design
+If your authorization model is sloppy, this middleware does not rescue it.
+A request that should require re-auth, step-up auth, or stronger intent signaling still requires those things.
+
+### 2. It does not make state-changing GET okay
+If you still mutate state on `GET`, you are building on sand.
+The protection explicitly treats safe methods differently. If you misuse “safe,” you undercut the whole model.
+
+### 3. It is not broader application security
+It does nothing for server-side authorization bugs, confused-deputy logic, XSS, weak session handling, or API designs that let the wrong caller do the wrong thing.
+
+### 4. It is not a promise that every request carries perfect browser provenance
+This feature depends on headers and request context. That is good enough to be useful; it is not the same as cryptographic proof of user intent.
+
+## The sharp edge maintainers should actually remember
+Go 1.25.1 and 1.24.7 shipped a security fix for `CrossOriginProtection.AddInsecureBypassPattern`.
+The issue was that bypass patterns were broader than intended: requests that would redirect to those patterns could also be exempted.
+That became [CVE-2025-47910](https://go.dev/issue/75054).
+
+That is not a reason to avoid the middleware.
+It **is** a reason to treat bypass rules like scalpels, not convenience flags.
+
+My maintainer read is simple:
+- prefer wrapping the handlers you want protected
+- use `AddTrustedOrigin` only for deliberate cross-origin flows you can explain out loud
+- avoid insecure bypass patterns unless you have a very specific reason
+- if you do use bypasses, make sure you are on a fixed Go release
+
+The first week after adopting a new safety API is a terrible time to sprinkle exemptions until the logs go quiet.
+
+## Where this helps most in real services
+The sweet spot is boring, session-based web software:
+- admin panels
+- internal tools
+- dashboards
+- settings/account flows
+- small to medium services with cookie auth and ordinary HTML/browser traffic
+
+In those systems, “reject obviously cross-site state-changing requests” is a very good default.
+The feature removes ambient footguns without forcing every team to re-assemble the same middleware story from scratch.
+
+## Rollout advice for maintainers
+If I owned a Go web service and wanted to operationalize this sanely, I would do it in this order:
+
+1. **Patch first.** Use a release that includes the bypass-pattern fix if you are on the 1.25 line.
+2. **Inventory state-changing routes.** Be clear about which handlers mutate state and which ones only read.
+3. **Fix method misuse.** Eliminate state-changing `GET` handlers before congratulating yourself about CSRF protection.
+4. **Wrap the app with the middleware.** Start with the straightforward default.
+5. **Add trusted origins sparingly.** Every extra trusted origin should correspond to an intentional product flow.
+6. **Be suspicious of bypasses.** If you need them, document exactly why.
+7. **Watch real traffic.** Especially for older clients, embedded flows, or weird internal integrations that may not look like normal browser traffic.
+
+## Maintainer takeaway
+Use `CrossOriginProtection` to remove ambient CSRF exposure you do not need.
+Do **not** use it as an excuse to weaken method discipline, auth boundaries, or explicit intent checks.
+
+The honest pitch is not “Go solved CSRF in the stdlib.”
+It is this:
+
+**Go made it cheaper to reject one very common class of cross-site browser mistakes. You should probably adopt that, and you should definitely avoid pretending it is more than that.**


### PR DESCRIPTION
Refs #218

Initial draft for the CrossOriginProtection maintainer post.

What's in here:
- practical framing around ambient CSRF risk
- one minimal stdlib example
- explicit limitations / non-goals
- rollout advice for maintainers
- note about the 1.25.1 / 1.24.7 bypass-pattern security fix

Local validation status:
- `npm ci` ✅
- `npm run build` currently blocked on this host by missing local Chromium shared library `libnss3.so` during Mermaid preflight

Next pass should tighten any wording around older/missing browser metadata cases against the upstream docs/source if needed.