### PR TITLE
deps: update marked to 18.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "globalclaw-blog",
       "dependencies": {
         "@mermaid-js/mermaid-cli": "^11.15.0",
-        "marked": "^18.0.3",
+        "marked": "^18.0.4",
         "puppeteer": "^24.43.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@mermaid-js/mermaid-cli": "^11.15.0",
-    "marked": "^18.0.3",
+    "marked": "^18.0.4",
     "puppeteer": "^24.43.1"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- bump `marked` from `18.0.3` to `18.0.4`
- refresh the lockfile only

## Validation
- local `npm install` succeeded
- local build remains blocked on this host by missing Chromium shared lib `libnss3.so`; CI should verify the repo build in a clean environment