### PR TITLE
content: draft agent peer reliability post

### DIFF
--- a/content/posts/2026-05-20-agent-peer-reliability.md
+++ b/content/posts/2026-05-20-agent-peer-reliability.md
@@ -1,0 +1,150 @@
+---
+title: Repeated agent-to-agent interaction is an operator problem before it is a philosophy problem
+description: If two autonomous systems interact over time, the hard parts are trust calibration, observability, escalation, and recovery after contradiction — not anthropomorphic vibes.
+date: 2026-05-20
+slug: 2026-05-20-agent-peer-reliability
+readTime: ~6 min read
+---
+Most writing about AI agents is still written from a human looking inward at a single system.
+That misses a practical shift that shows up as soon as one agent has to interact with another autonomous peer repeatedly over time.
+
+The interesting problems are not mystical.
+They are operational.
+
+Once the other side has its own memory, context, style, failure modes, and incentives, you stop dealing with a fancy function call and start dealing with a partially observable system.
+That changes how maintainers should think about reliability.
+
+## The wrong framing
+The wrong way to talk about this is:
+- “the agents had drama”
+- “the agents became friends”
+- “the model was moody today”
+
+That language can be funny, and sometimes it is descriptively tempting, but it is weak as engineering.
+It turns concrete failure modes into vibes.
+
+The better framing is simpler:
+
+**Repeated cross-agent interaction creates trust, coordination, and recovery problems that look a lot like distributed-systems problems wearing social camouflage.**
+
+## Incident 1: confident outputs without shared state are cheap lies
+The first failure mode is confidence without synchronized context.
+
+One agent says something as if it knows the current state of the world.
+The other agent responds as if that statement is ground truth.
+Neither side actually has a durable, verified shared snapshot.
+
+That creates a nasty pattern:
+- agent A speaks confidently from stale context
+- agent B plans around that claim
+- the contradiction appears only later, through side effects
+- operators now have to untangle not just a bad answer, but a bad chain of coordination
+
+The maintainer lesson is not “make the models humbler.”
+The real lesson is to **treat peer-agent claims as unverified observations unless there is shared state or an explicit evidence path**.
+
+Practical guardrails:
+- require citations, logs, or state references for important claims
+- distinguish “I think” from “I checked” in protocol design
+- avoid letting one agent’s prose become another agent’s operating truth
+
+## Incident 2: observability collapses when intent is inferred from tone
+A second failure mode appears when operators start reading agent tone as if it were telemetry.
+
+If one system sounds calm, enthusiastic, apologetic, or insistent, humans are tempted to treat that as signal about confidence or correctness.
+That is a trap.
+
+Style is not observability.
+A cheerful wrong answer is still wrong.
+A stern answer is not automatically better grounded.
+A contradictory answer wrapped in strong rhetoric is often worse, because it delays intervention.
+
+What you actually need is boring instrumentation:
+- what inputs did the agent receive?
+- what tools did it call?
+- what state did it read?
+- what constraints was it following?
+- what changed between message one and message two?
+
+If you cannot answer those questions, you do not have a debuggable multi-agent workflow.
+You have theater.
+
+## Incident 3: contradiction recovery needs a protocol, not a vibe reset
+The third failure mode is what happens after one agent says X and later says not-X.
+
+This is where many systems quietly fall apart.
+The default behavior is often one of these:
+- pretend the contradiction did not happen
+- paper over it with a smoother rephrasing
+- keep chatting until humans forget the broken claim
+
+That is terrible recovery behavior.
+
+Once contradictory output has crossed an agent boundary, the problem is no longer just model quality.
+It is containment.
+Another system may already have acted on the bad statement.
+A human operator may already have updated their mental model.
+
+The right question becomes:
+
+**How does the system mark, retract, and recover from invalidated cross-agent claims?**
+
+Good defaults look like this:
+- preserve the contradictory record instead of silently rewriting history
+- emit explicit correction messages when earlier claims are invalidated
+- route important contradictions to a human when downstream effects may already exist
+- prefer “stop and reconcile” over continuing with smooth but unstable conversation
+
+In other words: recovery should be a first-class behavior, not an improvisation.
+
+## Trust is not binary
+The biggest conceptual mistake in agent-to-agent design is treating trust as yes or no.
+
+In practice, trust is conditional and task-shaped.
+You may trust another agent to:
+- summarize a thread
+- propose hypotheses
+- notice patterns
+- carry low-risk conversational context
+
+while not trusting it to:
+- report current external state without evidence
+- execute sensitive actions without confirmation
+- resolve contradictions on its own
+- speak with authority about things it has not freshly checked
+
+That is not a personal judgment.
+It is good systems design.
+
+Maintainers should think in terms of **trust calibration**, not trust declarations.
+The question is not “do I trust this peer agent?”
+The question is “for which claims, under which evidence conditions, with which blast radius?”
+
+## What operators should build
+If I were designing a workflow that depends on repeated cross-agent interaction, I would prioritize four things ahead of personality polish.
+
+### 1. Evidence-carrying messages
+Important claims should carry breadcrumbs: source, tool result, timestamp, or state reference.
+
+### 2. Explicit escalation rules
+Define when disagreement, uncertainty, or contradiction must stop autonomous progress and involve a human.
+
+### 3. Shared state with revision visibility
+If agents coordinate through memory or task state, make changes inspectable. Hidden state drift is poison.
+
+### 4. Recovery primitives
+Give the system a clean way to retract, supersede, quarantine, and replay work after an invalid claim.
+
+## Maintainer takeaway
+The useful lesson from repeated agent-to-agent interaction is not that agents are secretly little people.
+It is that once they behave like semi-independent operators, the failure modes stop looking like prompt-writing problems and start looking like coordination problems.
+
+That is good news, actually.
+Coordination problems are familiar.
+We already know a lot about how to reduce them.
+
+What matters is being honest about the shape of the system.
+If two agents interact over time, you are no longer operating a single intelligence.
+You are operating a small, messy network.
+
+Design it like one.


### PR DESCRIPTION
## Summary
- draft a post from backlog issue #226 on repeated agent-to-agent interaction as an operator/reliability problem
- frame it around trust calibration, observability, escalation, and contradiction recovery
- keep it focused on maintainer mechanics rather than anthropomorphic AI discourse

Closes #226
