### PR TITLE
post: cargo alternate-registry toolchain freshness

### DIFF
--- a/content/posts/2026-05-20-cargo-alt-registry-toolchain-freshness.md
+++ b/content/posts/2026-05-20-cargo-alt-registry-toolchain-freshness.md
@@ -1,0 +1,111 @@
+---
+title: Cargo’s tar extraction bug is a reminder that registry trust and toolchain freshness are separate things
+description: CVE-2026-33056 was not just an "upgrade Rust" story. The real maintainer lesson is that crates.io mitigations do not automatically protect alternate registries or older Cargo clients.
+date: 2026-05-20
+slug: 2026-05-20-cargo-alt-registry-toolchain-freshness
+readTime: ~6 min read
+---
+CVE-2026-33056 is a good example of a security incident where the obvious summary is true but incomplete.
+Yes, you should update Rust and Cargo.
+But the more interesting maintainer lesson is that **registry-level mitigation and client/toolchain-level exposure are not the same layer**.
+
+That matters because the affected path sat in build tooling people often treat as boring background infrastructure.
+Boring infrastructure is exactly where stale assumptions like to hide.
+
+Primary source:
+- [Rust security advisory for CVE-2026-33056](https://blog.rust-lang.org/2026/03/21/cve-2026-33056/)
+
+## What the bug was
+The Rust advisory says the third-party `tar` crate used by Cargo during package extraction allowed a malicious crate to change permissions on arbitrary directories on the filesystem when Cargo extracted it during a build.
+
+That is already enough to trigger the right maintainer instinct:
+- this is not an app-runtime bug
+- this is not a theoretical parser nit
+- this sits in the supply path of normal development and CI work
+
+When the tool that fetches and unpacks dependencies mishandles malicious input, the blast radius is bigger than one library using one bad API.
+It touches the boring machinery teams rely on every day.
+
+## The response asymmetry is the real lesson
+The advisory also made an important distinction.
+For the public crates.io registry, the Rust team deployed a server-side mitigation quickly and audited the registry for exploitation.
+They said they found no published crates on crates.io exploiting the issue.
+
+That is good news.
+It is also where some teams stop thinking.
+
+The advisory explicitly called out **alternate registries** as a separate exposure question.
+If you use a private registry, vendor-managed mirror, or custom package flow, the crates.io mitigation does not automatically cover you.
+Likewise, a patched future release does not retroactively protect older Cargo clients already in use across laptops, builders, and CI runners.
+
+That is the real maintainer frame:
+
+**"crates.io is mitigated" does not mean "our package intake path is safe."**
+
+## Why this class of incident is operational, not dramatic
+This is not a reason for generic supply-chain panic.
+It is a reason to be honest about where your trust boundaries actually are.
+
+Many teams unconsciously compress several different claims into one:
+- we use Rust
+- we use Cargo
+- crates.io exists
+- therefore our dependency intake path is effectively handled
+
+But those are separate layers:
+- registry policy and server-side defenses
+- client/toolchain version in real environments
+- alternate registries and internal mirrors
+- source trust assumptions for what gets built where
+
+Security incidents get easier to survive when those layers stay separate in your head.
+They get uglier when teams treat "the ecosystem fixed it" as a single magical state.
+
+## What maintainers should do after reading the advisory
+If I owned Rust build infrastructure, I would turn this advisory into a short checklist.
+
+### 1. Patch the toolchain, not just the mental model
+If some builders, CI images, or developer machines are old enough to miss the fix, then your exposure story is still mixed.
+Do not stop at "the release exists." Verify where your actual Cargo versions sit.
+
+### 2. Inventory alternate registries and mirrors
+The advisory was explicit here for a reason.
+If you use anything other than plain public crates.io flows, identify who owns mitigation on that path and what they actually changed.
+
+### 3. Treat dependency extraction as part of the trusted computing base
+People often reserve serious threat thinking for production services.
+Build systems deserve some of that seriousness too.
+If malicious package extraction can affect filesystem state, your builder is part of the attack surface, not just a neutral conveyor belt.
+
+### 4. Keep toolchain refresh boring and fast
+The healthiest teams make this kind of update mundane.
+Not heroic.
+Not debated for three weeks.
+Just executed.
+A stale build toolchain is the kind of risk that quietly compounds until a real incident gives it a name.
+
+### 5. Be explicit about source trust assumptions
+If internal teams can publish to private registries, or if external sources flow through mirrors into trusted environments, write down what checks exist and which ones do not.
+"It comes from inside our ecosystem" is not a control.
+
+## The wrong takeaway
+The wrong takeaway is: Rust had a security bug, therefore everything is scary.
+That is lazy.
+
+The better takeaway is narrower and more useful:
+- server-side registry mitigations are valuable
+- client-side patching still matters
+- alternate registries need their own exposure review
+- build tooling deserves the same operational discipline as runtime dependencies
+
+## Maintainer takeaway
+CVE-2026-33056 is worth remembering because it cleanly separates two questions teams often blur together:
+1. **Did the public ecosystem respond well?**
+2. **Did our actual build path become safe?**
+
+In this case, the Rust ecosystem response looks solid.
+That does not remove the obligation to patch your toolchain and inspect your non-default package flows.
+
+That is the boring rule I would keep:
+
+**Never let a registry-level mitigation trick you into skipping client-level maintenance.**


### PR DESCRIPTION
## Summary
- add a short maintainer-focused post on CVE-2026-33056
- center the real lesson on alternate registries vs. client/toolchain freshness
- keep the framing operational instead of supply-chain fearmongering

## Validation
- `npm ci`
- `npm run build` *(blocked locally on this host by missing Chromium shared lib `libnss3.so`; same known VM dependency issue as earlier, so CI should be the real gate here)*
