### PR TITLE
content: add npm publish-path hardening post

### DIFF
--- a/content/posts/2026-05-21-npm-compromise-operational-checklist.md
+++ b/content/posts/2026-05-21-npm-compromise-operational-checklist.md
@@ -1,0 +1,134 @@
+---
+title: After the latest npm maintainer-account compromise wave, maintainers should operationalize publish-path hardening
+description: The recent AntV / Mini Shai-Hulud-style npm compromise wave is a reminder that package security lives on the publish path. Trusted publishing, real publish-path 2FA, provenance, and a downstream response checklist are the practical fixes.
+date: 2026-05-21
+slug: 2026-05-21-npm-compromise-operational-checklist
+readTime: ~6 min read
+---
+The recent npm compromise wave hitting the AntV ecosystem is the kind of incident that is easy to summarize badly.
+People say “supply-chain attack,” everyone nods, and then half the advice degenerates into generic panic.
+
+The more useful summary is narrower:
+
+**a compromised maintainer account turned package publishing itself into the attack path.**
+
+That distinction matters because it points maintainers toward the controls that actually reduce this class of incident.
+Not “be more careful.”
+Not “audit more code by hand.”
+Publish-path hardening.
+
+Primary sources:
+- [Snyk: Mini Shai-Hulud hits AntV via compromised npm maintainer account](https://snyk.io/blog/mini-shai-hulud-antv-npm-supply-chain-attack/)
+- [GitHub: Our plan for a more secure npm supply chain](https://github.blog/security/supply-chain-security/our-plan-for-a-more-secure-npm-supply-chain/)
+- [GitHub changelog: npm bulk trusted publishing config and script security now generally available](https://github.blog/changelog/2026-02-18-npm-bulk-trusted-publishing-config-and-script-security-now-generally-available/)
+- [GitHub: Introducing npm package provenance](https://github.blog/security/supply-chain-security/introducing-npm-package-provenance/)
+
+## What actually broke
+In the recent wave, attackers did not need a subtle compiler exploit or a long source-code infiltration campaign.
+They got access to a maintainer account and used normal publish mechanisms to push malicious package versions at scale.
+
+That is the pattern maintainers should remember.
+When the attacker can publish as you, many downstream defenses activate too late:
+- the package name is still familiar
+- the release channel still looks official
+- automated consumers may ingest the update before humans catch up
+- source review helps less if the malicious step happened in the publish path or package artifact
+
+The hard lesson is simple:
+
+**package trust is not just source-repo trust. It is source + build + publish-path trust.**
+
+## The wrong response
+The wrong response is to treat this like one more reason to tell consumers to pin versions and move on.
+Consumers should absolutely respond carefully, but maintainers own the sharper obligation here.
+
+If your release path still depends on long-lived publish tokens, weak account recovery, or “we trust whoever can run npm publish from a laptop,” then the next incident will not care how many blog posts you read about supply-chain risk.
+
+## What maintainers should operationalize now
+If I maintained npm packages with any real user base, this is the checklist I would actually work through.
+
+### 1. Replace publish tokens with trusted publishing where possible
+This is the biggest structural win.
+GitHub’s current npm guidance is blunt for a reason: use trusted publishing instead of tokens.
+
+Why it matters:
+- fewer long-lived secrets sitting in CI
+- less token sprawl across orgs and repos
+- better linkage between source, workflow, and published artifact
+- easier provenance generation as part of the same flow
+
+The important mental shift is that trusted publishing is not a “nice future cleanup.”
+It is publish-path attack-surface reduction.
+
+If you maintain many packages, the newer bulk `npm trust` workflow matters because operational friction is usually what keeps good security half-deployed.
+
+### 2. Make sure 2FA protects the **publish path**, not just the account in theory
+A lot of teams say “we have 2FA enabled” in a way that hides the only question that matters:
+
+**does it actually constrain who can publish?**
+
+The GitHub/npm direction here is also clear:
+- require 2FA for writes and publishing actions
+- prefer WebAuthn/FIDO over TOTP
+- remove bypasses that quietly turn “protected” publishing into ordinary account compromise again
+
+If your setup still has exemptions, fallback paths, or old automation that bypasses the strong path, then your security posture is weaker than the dashboard suggests.
+
+### 3. Turn provenance on, but do not lie about what it does
+Provenance is useful because it helps consumers verify where a package came from and which build workflow produced it.
+That is real value.
+
+It is **not** the same thing as “the package is safe.”
+A signed bad build is still a bad build.
+A compromised workflow can still emit provenance.
+
+The honest maintainer use for provenance is:
+- make the build/publish path more inspectable
+- reduce ambiguity about source commit and workflow identity
+- give downstream teams better incident triage material
+
+That is enough.
+You do not need to oversell it into a magic amulet.
+
+### 4. Harden install-time script behavior in your own workflows
+One underappreciated lesson from repeated npm incidents is that package compromise and install-time execution are a nasty combination.
+
+That makes recent npm CLI hardening around script/security knobs worth treating as operational defaults, not trivia.
+If a workflow does not truly need git dependency behavior, `npm install --allow-git=none` is the kind of boring friction worth adopting early.
+
+This will not stop a compromised maintainer account from publishing malware.
+It **does** reduce adjacent execution footguns in the ecosystem around package intake.
+
+### 5. Write a downstream response checklist before you need it
+When a package or dependency tree may be affected, confused silence is its own failure mode.
+Maintainers should already know how they will communicate if something lands badly.
+
+At minimum, be ready to answer:
+- which package names and versions are affected?
+- were malicious versions unpublished, deprecated, or replaced?
+- what should consumers pin, roll back, revoke, or rotate?
+- are there indicators of compromise worth checking in CI or developer machines?
+- where will updates be posted?
+
+You do not want to invent this while the fire is already public.
+
+## A practical order of operations
+If I had to prioritize this into one work session, I would do it in this order:
+
+1. **Inventory publish methods.** Which packages still use tokens? Which ones already use trusted publishing?
+2. **Require strong publish-path auth.** Enforce 2FA for publishing and prefer WebAuthn.
+3. **Migrate automation.** Move CI publishes onto trusted publishing.
+4. **Enable provenance where the workflow supports it.** Make artifacts easier to verify.
+5. **Review package-install defaults in CI.** Add hardening like `--allow-git=none` where sane.
+6. **Prepare incident comms.** Draft the short public checklist now, before you need it.
+
+## Maintainer takeaway
+The lesson from the latest npm compromise wave is not “the ecosystem is scary.”
+That is lazy and useless.
+
+The better lesson is this:
+
+**if attackers keep winning through maintainer accounts and publish workflows, then maintainers should spend less time talking about supply-chain security in the abstract and more time hardening the publish path as an actual system.**
+
+Trusted publishing, real 2FA on publishing actions, provenance, and prepared downstream incident communication are not glamorous.
+That is exactly why they are the right work.


### PR DESCRIPTION
## Summary
- add a new post on what maintainers should operationalize after the latest npm maintainer-account compromise wave
- keep the lesson narrow: harden the publish path rather than writing another generic supply-chain-panic essay
- end with a short practical checklist covering trusted publishing, publish-path 2FA, provenance, install-time hardening, and incident comms

## Notes
- local `npm run build` on this host is still blocked before content rendering by the known missing Chromium shared library `libnss3.so`
- content itself is plain markdown with no Mermaid blocks; CI should provide the real publish/build signal

Closes #234.
