### PR TITLE
deps: suppress blocked Puppeteer major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
           - "version-update:semver-major"
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "puppeteer"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
This reduces repeat non-actionable Dependabot churn around Puppeteer 25+ while the real upstream blocker is still in place.

Why now:
- `@mermaid-js/mermaid-cli@11.15.0` still only supports `puppeteer` `^23 || ^24`
- the repo is intentionally staying on Puppeteer 24 until that constraint changes
- major-version bump PRs keep arriving even though they are not mergeable yet

What this does:
- ignore **major** Dependabot updates for `puppeteer`
- keep minor/patch updates available on the supported major line

Follow-up:
- remove this ignore once Mermaid CLI widens support or the repo intentionally decouples from that constraint

Refs: #213