### PR TITLE
draft: add Go proxy trust-boundary post

### DIFF
--- a/content/posts/2026-05-21-go-proxy-checksum-trust-boundaries.md
+++ b/content/posts/2026-05-21-go-proxy-checksum-trust-boundaries.md
@@ -1,0 +1,77 @@
+---
+title: Go proxy trust boundaries matter more than teams think
+description: GO-2026-4984 is not just another stale dependency story. If you treat GOPROXY or a mirrored GOSUMDB as untrusted plumbing, your toolchain assumptions may already be wrong.
+date: 2026-05-21
+slug: 2026-05-21-go-proxy-checksum-trust-boundaries
+readTime: 4 min read
+---
+[GO-2026-4984](https://pkg.go.dev/vuln/GO-2026-4984) is easy to misread as a narrow Go vulnerability.
+
+The more useful maintainer lesson is broader:
+
+**`GOPROXY` and mirrored `GOSUMDB` instances are not just cache infrastructure. In practice, they can sit inside your toolchain trust boundary.**
+
+That matters because many teams talk about internal proxies like they are passive bandwidth helpers. They are not passive if a bad proxy response can influence which toolchain artifacts get accepted.
+
+## The mistake to avoid
+A lot of Go setups conceptually separate these layers:
+
+- the base Go installation is trusted
+- `toolchain` directives are a version-selection convenience
+- `GOPROXY` is just a fetch accelerator
+- `GOSUMDB` is the integrity backstop
+
+This issue is a reminder that those boundaries are tighter than they look.
+
+If your environment depended on a non-trusted `GOPROXY` or a mirrored checksum database, you were not only risking stale or wrong modules. You were letting infrastructure outside the intended trust perimeter influence toolchain download validation.
+
+That is a more serious operator mistake than “we forgot to bump a dependency.”
+
+## Why `toolchain` lines were not enough
+One trap here is assuming modern Go toolchain selection solves the problem by itself.
+
+It does not.
+
+Saying `toolchain go1.x.y` in `go.mod`, or setting `GOTOOLCHAIN`, does not remove the need to install a fixed base Go release. If the base installation is still vulnerable, the surrounding version-selection machinery does not magically make the trust problem disappear.
+
+The operational takeaway is blunt:
+
+**upgrade the base Go toolchain first.**
+
+Everything else is cleanup around that core action.
+
+## What maintainers should do
+Keep the response short and practical.
+
+### 1. Upgrade the base Go installation
+Move to a fixed Go release, not just a different `toolchain` directive. Treat this as a runtime/tooling patch, not a dependency hygiene chore.
+
+### 2. Re-evaluate your mirror trust model
+Ask a boring but important question:
+
+**Do we actually trust the systems serving `GOPROXY` and mirrored `GOSUMDB` enough to let them participate in our build trust boundary?**
+
+If the real answer is “not really,” then the architecture was already carrying more risk than the team admitted.
+
+### 3. Revalidate from a clean state if untrusted mirrors were involved
+If non-trusted mirror infrastructure was in play, clean up like you mean it:
+
+- regenerate dependency state as needed
+- run `go mod tidy`
+- run `go mod verify`
+- review whether `go.sum` reflects the dependency graph you actually intend to ship
+
+The goal is not ceremony. The goal is to stop carrying forward assumptions produced under a bad trust model.
+
+## The maintainer lesson
+The interesting part of this story is not “supply chain bad.” That sentence is too vague to help anyone.
+
+The useful lesson is narrower:
+
+**teams often classify build mirrors as convenience infrastructure long after those mirrors have become part of the trusted computing base.**
+
+Once that happens, your documentation, patch habits, and incident response should reflect reality.
+
+If your proxy tier can affect what toolchain material gets accepted, it is not a sidecar. It is part of the perimeter.
+
+That is the boundary worth fixing.


### PR DESCRIPTION
## Summary
- add a short draft post for issue #240 about GO-2026-4984
- focus the piece on trust boundaries around `GOPROXY`, mirrored `GOSUMDB`, and toolchain downloads
- keep the remediation section operational and concise

## Testing
- `npm run build` *(blocked on this VM by the known Mermaid/Puppeteer runtime dependency gap: missing `libnss3.so` before render phase)*

Closes #240.
