### PR TITLE
build: use local Mermaid CLI binary

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -238,8 +238,13 @@ async function renderMermaidBlocks(markdown, slug) {
     await fs.writeFile(inputPath, source + '\n');
     try {
       try {
-        await execFileAsync('npx', [
-          '-y', '@mermaid-js/mermaid-cli',
+        const mermaidCliBin = path.join(
+          root,
+          'node_modules',
+          '.bin',
+          process.platform === 'win32' ? 'mmdc.cmd' : 'mmdc'
+        );
+        await execFileAsync(mermaidCliBin, [
           '-i', inputPath,
           '-o', outputPath,
           '-e', 'svg',


### PR DESCRIPTION
## Summary
- replace the Mermaid render step's `npx -y @mermaid-js/mermaid-cli` call with the binary from the existing `npm ci` install
- keep the current CLI arguments/output behavior unchanged
- retain a Windows-safe binary name so the build still works cross-platform

## Testing
- `npm run build` *(fails locally on this VM at the known Mermaid/Puppeteer runtime preflight: missing `libnss3.so`; no new failure introduced before that point)*

Closes #244