### PR TITLE
post: add Trivy release-boundary piece

### DIFF
--- a/content/posts/2026-05-22-trivy-release-trust-boundaries-after-credential-theft.md
+++ b/content/posts/2026-05-22-trivy-release-trust-boundaries-after-credential-theft.md
@@ -1,0 +1,112 @@
+---
+title: After Trivy, release trust has to include tags, channels, and residual credentials
+description: The Trivy compromise is a maintainer reminder that secret rotation is not enough on its own. If tags, release channels, and workflow credentials stay mutable, attackers can come back through the same perimeter.
+date: 2026-05-22
+slug: 2026-05-22-trivy-release-trust-boundaries-after-credential-theft
+readTime: ~5 min read
+---
+The maintainer lesson from the Trivy compromise is not just “rotate credentials faster.”
+That is part of it, but it is too small.
+
+The harder lesson is this:
+
+**release trust is a whole boundary, and attackers will use whichever part of that boundary still moves.**
+
+In Trivy’s case, the public advisory is blunt: compromised credentials were used to publish a malicious `v0.69.4` release, force-push most `trivy-action` tags to credential-stealing commits, replace all `setup-trivy` tags, and later publish malicious Docker Hub images for `v0.69.5` and `v0.69.6`.
+The follow-up root-cause writeup is even more uncomfortable: earlier credential rotation after the March 1 incident was **not atomic**, which may have allowed the attacker to retain access and exfiltrate newly rotated secrets during the recovery window.
+
+Primary sources:
+- [GitHub advisory: Trivy ecosystem supply chain temporarily compromised](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23)
+- [Aqua update: ongoing investigation and continued remediation](https://www.aquasec.com/blog/trivy-supply-chain-attack-what-you-need-to-know/)
+- [GitHub docs: secure use reference for Actions](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions)
+- [GitHub docs: immutable releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release)
+
+## What broke, structurally
+This incident crossed several trust surfaces at once:
+- release credentials
+- GitHub Action tags
+- container distribution channels
+- residual access left alive during remediation
+
+That matters because too many maintainers still think of a compromise as one stolen secret plus one cleanup step.
+But the Trivy advisory reads more like a perimeter failure:
+- one malicious binary release
+- mutable action tags repointed to malware
+- later malicious Docker Hub images pushed through a separate channel
+- a rotation process that did not fully extinguish attacker access on the first pass
+
+If the attacker can survive your “we rotated the secrets” moment, then your recovery is not recovery yet.
+It is an overlap window.
+And overlap windows are where second-stage damage happens.
+
+## Why mutable references keep making incidents worse
+One of the ugliest details here is that many affected users were not just hit by “latest.”
+They were hit because trusted-looking version tags in GitHub Actions were force-moved to malicious commits.
+
+That is the quiet maintainership tax of mutable references:
+- tags look stable to humans
+- version labels look official in YAML
+- old workflows keep running without visible drift
+- defenders overestimate what “immutable” means in practice
+
+The advisory’s recommendation is exactly right: pin third-party GitHub Actions to full commit SHAs.
+Not because SHAs are fashionable, but because a tag name is still a movable signpost unless the surrounding release process truly makes it immovable.
+
+The same mindset applies to container images.
+If you depend on tags rather than digests, then “official image” can become “official-looking moving target” in the worst possible hour.
+
+## The remediation mistake maintainers should stop making
+The part I would underline in red is the advisory’s root-cause section: rotation was performed, but not atomically.
+That is the difference between revocation as theater and revocation as containment.
+
+A real response plan has to assume the attacker will try to do three things during cleanup:
+1. use still-valid credentials before they expire
+2. steal newly rotated credentials from partially trusted systems
+3. pivot into adjacent release channels you forgot were equivalent to the main one
+
+If your binary release path, Docker registry, GitHub Actions automation, service accounts, and org-level bot credentials are treated as separate little admin chores, an attacker will treat them as one connected graph instead.
+They will be right.
+
+## What I would change this week
+If I maintained a public release pipeline after reading the Trivy writeup, this is the work I would do first.
+
+### 1. Make credential revocation atomic where possible
+Do not rotate piecemeal over days if the system can be frozen and cut over faster.
+Inventory every credential that can publish, retag, trigger releases, push images, or alter workflows, then revoke the whole set as one incident boundary.
+If the process cannot do that today, the process itself is backlog-worthy security debt.
+
+### 2. Treat tags as high-risk release surfaces
+Protect release tags.
+Restrict who or what can move them.
+Assume tag mutation is equivalent to release tampering, because for downstream users it effectively is.
+
+### 3. Pin third-party Actions by full SHA
+This is the cheapest high-value default in the whole story.
+If you still trust `@v1`, `@v2`, or repo-owned version tags in sensitive workflows, you are outsourcing part of your security boundary to a mutable label.
+
+### 4. Prefer image digests over tags in critical paths
+A pinned digest is boring in the best way.
+If CI or production still depends on mutable image tags for security-sensitive tools, tighten that now.
+
+### 5. Reduce service-account blast radius
+Bot accounts and automation credentials should not be able to fan out across unrelated release surfaces just because it was convenient once.
+Separate duties where you can: workflow changes, binary releases, package publishing, and registry pushes should not all collapse into one overpowered identity.
+
+### 6. Monitor the release perimeter, not just the source repo
+Watch for force-pushed tags, unexpected release creation, registry tag churn, and suspicious workflow-trigger patterns.
+If your alerting only notices bad commits on `main`, you are staring at the wrong door.
+
+## Maintainer takeaway
+The Trivy incident is a reminder that compromise response is not complete when secrets are “rotated.”
+It is complete when the attacker has no remaining path to publish, retag, impersonate, or quietly re-enter through a sibling channel.
+
+That means the real unit of defense is bigger than one credential.
+It is the whole release boundary:
+- workflows
+- tags
+- registries
+- service accounts
+- rollback and recovery procedure
+
+If any of those stay soft, the next attacker does not need a new trick.
+They just need your recovery plan to leave one window unlatched.


### PR DESCRIPTION
Closes #249\n\nShort maintainer post on the Trivy compromise as a release-boundary lesson: atomic credential revocation, tag protection, SHA pinning, digest pinning, and reducing service-account blast radius.\n

Closes #249