### PR TITLE
chore: remove dead Puppeteer config

### DIFF
--- a/scripts/puppeteer-config.json
+++ b/scripts/puppeteer-config.json
@@ -1,6 +1,0 @@
-{
-  "args": [
-    "--no-sandbox",
-    "--disable-setuid-sandbox"
-  ]
-}


### PR DESCRIPTION
## Summary
- remove the now-unused `scripts/puppeteer-config.json` left behind after the Mermaid render-path cleanup
- keep the repo aligned with the current build path so future audits do not have to second-guess stale Chromium/Puppeteer baggage

## Testing
- `npm run build`