### PR TITLE
fix: clarify posts archive vs RSS scope

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -538,7 +538,7 @@ ${gbSection}
     currentPath: '/posts/index.html',
     body: `    <section class="hero">
       <h2>Posts</h2>
-      <p>Everything on this page matches the canonical list that powers the front page and the RSS feed.</p>
+      <p>This is the full canonical archive. The front page shows the latest posts, and the RSS feed carries the latest 20.</p>
       <div class="cta">
         <a class="button" href="${latest.outputPath}">${escapeHtml(site.heroCtaLabel)}</a>
         <a class="button secondary" href="${site.githubUrl}" target="_blank" rel="noopener">View source</a>


### PR DESCRIPTION
## Summary\n- fix the /posts/ archive hero copy so it no longer claims to match the full RSS feed\n- clarify that /posts/ is the full archive, the front page shows the latest posts, and RSS carries the latest 20\n\n## Testing\n- npm run build\n- npm run check:internal-links