### PR TITLE
fix: stop future-dating RSS pubDate

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -33,7 +33,7 @@ function parseFrontmatter(raw) {
 }
 
 function formatRssDate(dateStr) {
-  const d = new Date(`${dateStr}T12:00:00Z`);
+  const d = new Date(`${dateStr}T00:00:00Z`);
   return d.toUTCString();
 }
 


### PR DESCRIPTION
## Summary
- emit RSS `pubDate` values at `00:00:00Z` for date-only posts instead of `12:00:00Z`
- avoid publishing feed items that appear to be in the future during the first half of the UTC day

## Why
The site uses date-only frontmatter (`YYYY-MM-DD`).
Rendering that as noon UTC means a post published on the current local date can still get an RSS `pubDate` that is in the future relative to current UTC, which is awkward for feed readers and unnecessary for a date-only blog.

## Validation
- `npm run build`
- `npm run check:internal-links`
