### PR TITLE
fix: enforce canonical dated post slugs

### DIFF
--- a/content/posts/2026-02-24-llm-token-caching.md
+++ b/content/posts/2026-02-24-llm-token-caching.md
@@ -2,8 +2,6 @@
 title: LLM token caching: what it is, why it’s fast, and how to use it
 description: An introduction to LLM token (KV) caching, prompt caching, and practical strategies for saving latency and cost.
 date: 2026-02-24
-slug: 2026-02-24-llm-token-caching
-redirectFrom: /posts/llm-token-caching.html
 readTime: ~7 min read
 ---
 If you’ve used an LLM API for a while, you’ve probably noticed a pattern: many requests repeat the same

--- a/scripts/build-gb.mjs
+++ b/scripts/build-gb.mjs
@@ -31,8 +31,9 @@ function parseFrontmatter(raw) {
   return { data, body: raw.slice(end + 5) };
 }
 
-function validatePostSourcePath(name, date) {
-  const match = name.match(/^(\d{4}-\d{2}-\d{2})-/);
+function validatePostSourcePath(name, date, slug) {
+  const stem = name.replace(/\.md$/, '');
+  const match = stem.match(/^(\d{4}-\d{2}-\d{2})-/);
   if (!match) {
     throw new Error(`Invalid post source filename \"${name}\": expected content/posts/YYYY-MM-DD-slug.md`);
   }
@@ -42,6 +43,10 @@ function validatePostSourcePath(name, date) {
   if (match[1] !== date) {
     throw new Error(`Date mismatch for post \"${name}\": filename prefix is ${match[1]} but frontmatter date is ${date}`);
   }
+  if (slug && slug !== stem) {
+    throw new Error(`Slug mismatch for post \"${name}\": frontmatter slug is ${slug} but canonical slug is ${stem}`);
+  }
+  return stem;
 }
 
 function markdownToPlainText(input) {
@@ -127,8 +132,7 @@ async function loadPosts() {
     const fullPath = path.join(postsDir, name);
     const raw = await fs.readFile(fullPath, 'utf8');
     const { data, body } = parseFrontmatter(raw);
-    validatePostSourcePath(name, data.date);
-    const slug = data.slug || name.replace(/\.md$/, '');
+    const slug = validatePostSourcePath(name, data.date, data.slug);
     loaded.push({
       slug,
       title: sanitizeTitle(data.title, slug),

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -32,8 +32,9 @@ function parseFrontmatter(raw) {
   return { data, body };
 }
 
-function validatePostSourcePath(name, date) {
-  const match = name.match(/^(\d{4}-\d{2}-\d{2})-/);
+function validatePostSourcePath(name, date, slug) {
+  const stem = name.replace(/\.md$/, '');
+  const match = stem.match(/^(\d{4}-\d{2}-\d{2})-/);
   if (!match) {
     throw new Error(`Invalid post source filename \"${name}\": expected content/posts/YYYY-MM-DD-slug.md`);
   }
@@ -43,6 +44,10 @@ function validatePostSourcePath(name, date) {
   if (match[1] !== date) {
     throw new Error(`Date mismatch for post \"${name}\": filename prefix is ${match[1]} but frontmatter date is ${date}`);
   }
+  if (slug && slug !== stem) {
+    throw new Error(`Slug mismatch for post \"${name}\": frontmatter slug is ${slug} but canonical slug is ${stem}`);
+  }
+  return stem;
 }
 
 function formatRssDate(dateStr) {
@@ -275,8 +280,7 @@ async function readMarkdownPosts() {
   for (const name of names) {
     const raw = await fs.readFile(path.join(dir, name), 'utf8');
     const { data, body } = parseFrontmatter(raw);
-    validatePostSourcePath(name, data.date);
-    const slug = data.slug || name.replace(/\.md$/, '');
+    const slug = validatePostSourcePath(name, data.date, data.slug);
     const preserved = preserveRawBlocks(body);
     posts.push({
       source: 'markdown',


### PR DESCRIPTION
## Summary
- stop letting frontmatter `slug` override the canonical dated post source path
- make both web and Game Boy builds fail fast if a markdown post's optional `slug` drifts from its filename stem
- remove the stale legacy slug override from `2026-02-24-llm-token-caching.md` so it now publishes at the dated canonical URL

## Verification
- `npm run build`
- `npm run check:internal-links`
- `npm run build:gb:data`
