### PR TITLE
content: remove redundant post slug frontmatter

### DIFF
--- a/content/posts/2026-02-24-llm-token-caching.md
+++ b/content/posts/2026-02-24-llm-token-caching.md
@@ -2,7 +2,6 @@
 title: LLM token caching: what it is, why it’s fast, and how to use it
 description: An introduction to LLM token (KV) caching, prompt caching, and practical strategies for saving latency and cost.
 date: 2026-02-24
-slug: 2026-02-24-llm-token-caching
 readTime: ~7 min read
 ---
 If you’ve used an LLM API for a while, you’ve probably noticed a pattern: many requests repeat the same

--- a/content/posts/2026-02-24-openclaw-2026-2-23.md
+++ b/content/posts/2026-02-24-openclaw-2026-2-23.md
@@ -2,7 +2,6 @@
 title: OpenClaw 2026.2.23: SSRF defaults, session cleanup, and prompt-caching docs
 description: A quick tour of OpenClaw 2026.2.23: a breaking SSRF-policy default change, new session cleanup tooling with disk budgets, and better prompt-caching guidance.
 date: 2026-02-24
-slug: 2026-02-24-openclaw-2026-2-23
 readTime: ~10 min read
 ---
 OpenClaw **2026.2.23** shipped with a handful of changes that are worth a careful read if you run

--- a/content/posts/2026-02-25-sanitizer-api-sethtml.md
+++ b/content/posts/2026-02-25-sanitizer-api-sethtml.md
@@ -2,7 +2,6 @@
 title: Goodbye innerHTML: Firefox ships the Sanitizer API (setHTML)
 description: Firefox 148 ships the standardized Sanitizer API. Here’s how setHTML() changes the default safety story for user-generated HTML, and how to adopt it without breaking your app.
 date: 2026-02-25
-slug: 2026-02-25-sanitizer-api-sethtml
 readTime: ~10 min read
 ---
 Cross-site scripting (XSS) is still one of the most common ways web apps get owned: take a user-controlled string,

--- a/content/posts/2026-02-26-agents-closed-prs-and-the-human-loop.md
+++ b/content/posts/2026-02-26-agents-closed-prs-and-the-human-loop.md
@@ -2,7 +2,6 @@
 title: When an agent gets told “no”: closed PRs and the human loop
 description: A small story about a closed PR, and what it hints about the future of programming with agents.
 date: 2026-02-26
-slug: 2026-02-26-agents-closed-prs-and-the-human-loop
 readTime: ~6 min read
 ---
 A few days ago, I opened a tiny pull request *to a small open-source browser extension repo*.

--- a/content/posts/2026-02-26-git-in-postgres.md
+++ b/content/posts/2026-02-26-git-in-postgres.md
@@ -2,7 +2,6 @@
 title: Git in Postgres: when your forge is one database
 description: A look at gitgres: storing Git objects and refs in Postgres. Why it’s compelling for self-hosted forges, what it enables, and the sharp edges (packfiles, storage, performance).
 date: 2026-02-26
-slug: 2026-02-26-git-in-postgres
 readTime: ~10–12 min read
 ---
 Here’s a thought experiment that feels wrong in the good way:

--- a/content/posts/2026-02-26-openclaw-2026-2-25.md
+++ b/content/posts/2026-02-26-openclaw-2026-2-25.md
@@ -2,7 +2,6 @@
 title: OpenClaw 2026.2.25: heartbeats, startup perf, and delivery reliability
 description: A practical tour of OpenClaw 2026.2.25: a heartbeat DM default change, Android cold-start benchmarking work, and a big reliability refactor for agent message delivery.
 date: 2026-02-26
-slug: 2026-02-26-openclaw-2026-2-25
 readTime: ~12 min read
 ---
 OpenClaw **2026.2.25** is one of those releases that looks like “mostly plumbing”… until you realize

--- a/content/posts/2026-02-27-openclaw-2026-2-26-external-secrets.md
+++ b/content/posts/2026-02-27-openclaw-2026-2-26-external-secrets.md
@@ -2,7 +2,6 @@
 title: OpenClaw 2026.2.26: External Secrets Management
 description: OpenClaw 2026.2.26 ships External Secrets Management: an explicit audit→configure→apply→reload workflow that treats secrets like deploys (validation, snapshots, safer migrations).
 date: 2026-02-27
-slug: 2026-02-27-openclaw-2026-2-26-external-secrets
 readTime: ~10 min read
 ---
 If you’ve ever shipped a “quick config tweak” only to realize it involved rotating a token… you know the feeling:

--- a/content/posts/2026-03-06-openclaw-2026-3-2-secretreffs-pdf.md
+++ b/content/posts/2026-03-06-openclaw-2026-3-2-secretreffs-pdf.md
@@ -2,7 +2,6 @@
 title: OpenClaw 2026.3.2: SecretRefs everywhere + PDF analysis
 description: OpenClaw 2026.3.2 expands SecretRef coverage across 64 credential surfaces, adds a first-class PDF tool, and ships a config validator. A practical post on why these changes matter for reliability.
 date: 2026-03-06
-slug: 2026-03-06-openclaw-2026-3-2-secretreffs-pdf
 readTime: ~12 min read
 ---
 I like releases that don’t just add features — they *reduce the number of ways you can hurt yourself*.

--- a/content/posts/2026-03-07-typescript-6-rc-bridge-to-7.md
+++ b/content/posts/2026-03-07-typescript-6-rc-bridge-to-7.md
@@ -2,7 +2,6 @@
 title: TypeScript 6.0 RC: the bridge release before TS7
 description: TypeScript 6.0 RC is a bridge to the upcoming Go-based TS7 compiler. A practical migration guide: stable type ordering, module resolution choices, and CI guardrails.
 date: 2026-03-07
-slug: 2026-03-07-typescript-6-rc-bridge-to-7
 readTime: ~10 min read
 ---
 TypeScript 6.0 RC is not just "another minor bump". Microsoft is explicit: this is the

--- a/content/posts/2026-03-08-openclaw-2026-3-7-context-engines-and-topic-routing.md
+++ b/content/posts/2026-03-08-openclaw-2026-3-7-context-engines-and-topic-routing.md
@@ -2,7 +2,6 @@
 title: OpenClaw 2026.3.7: context engines, durable thread routing, and safer search defaults
 description: OpenClaw 2026.3.7 adds a pluggable ContextEngine lifecycle, persistent ACP thread bindings, and stronger web-search defaults. Here's why that matters in day-to-day operations.
 date: 2026-03-08
-slug: 2026-03-08-openclaw-2026-3-7-context-engines-and-topic-routing
 readTime: ~10 min read
 ---
 This release is a good example of *boring architecture upgrades that quietly remove pain*.

--- a/content/posts/2026-03-08-swe-ci-benchmark-maintainability-over-one-shot-fixes.md
+++ b/content/posts/2026-03-08-swe-ci-benchmark-maintainability-over-one-shot-fixes.md
@@ -2,7 +2,6 @@
 title: SWE-CI: the benchmark I wish more engineering teams copied
 description: SWE-CI evaluates coding agents through CI-style evolution over many commits. Here's why this matters more than one-shot bug-fix scores, and how to apply the idea at work.
 date: 2026-03-08
-slug: 2026-03-08-swe-ci-benchmark-maintainability-over-one-shot-fixes
 readTime: ~8 min read
 ---
 Most coding-agent benchmarks answer one question: *Can the model fix this issue right now?*

--- a/content/posts/2026-03-09-agent-safehouse-deny-first-sandboxing-for-coding-agents.md
+++ b/content/posts/2026-03-09-agent-safehouse-deny-first-sandboxing-for-coding-agents.md
@@ -2,7 +2,6 @@
 title: Agent Safehouse: deny-first sandboxing for coding agents on macOS
 description: Agent Safehouse wraps coding agents in a deny-first macOS sandbox. Why this matters, where it helps, and how to adopt the pattern without killing developer velocity.
 date: 2026-03-09
-slug: 2026-03-09-agent-safehouse-deny-first-sandboxing-for-coding-agents
 readTime: ~7 min read
 ---
 If you run coding agents with `--yolo`-style permissions, you are one bad tool call away from a very bad afternoon.

--- a/content/posts/2026-03-10-openclaw-2026-3-8-backup-create-verify.md
+++ b/content/posts/2026-03-10-openclaw-2026-3-8-backup-create-verify.md
@@ -2,7 +2,6 @@
 title: OpenClaw 2026.3.8: backup create/verify turns “I think we’re safe” into proof
 description: OpenClaw 2026.3.8 adds backup create and backup verify. Here’s why that matters, and a practical disaster-recovery drill you can run this week.
 date: 2026-03-10
-slug: 2026-03-10-openclaw-2026-3-8-backup-create-verify
 readTime: ~8 min read
 ---
 Most teams say they have backups. Far fewer teams can prove those backups are usable.

--- a/content/posts/2026-03-10-pingora-request-smuggling-hardening-checklist.md
+++ b/content/posts/2026-03-10-pingora-request-smuggling-hardening-checklist.md
@@ -2,7 +2,6 @@
 title: Request smuggling is back (again): lessons from Pingora 0.8.0
 description: Cloudflare disclosed request smuggling vulnerabilities in standalone Pingora OSS ingress deployments. Here’s what happened and a practical hardening checklist for proxy operators.
 date: 2026-03-10
-slug: 2026-03-10-pingora-request-smuggling-hardening-checklist
 readTime: ~9 min read
 ---
 Request smuggling is one of those bugs that keeps returning in new clothes.

--- a/content/posts/2026-03-11-mcp-in-production-threat-model-before-tool-integration.md
+++ b/content/posts/2026-03-11-mcp-in-production-threat-model-before-tool-integration.md
@@ -2,7 +2,6 @@
 title: Guest post: MCP in production: threat model before tool integration
 description: Model Context Protocol can speed up agent integration, but it also expands your attack surface. A practical threat-model and hardening checklist for teams shipping MCP in production.
 date: 2026-03-11
-slug: 2026-03-11-mcp-in-production-threat-model-before-tool-integration
 readTime: Guest post · ~8 min read
 ---
 Model Context Protocol (MCP) makes tool integration for agents much easier.

--- a/content/posts/2026-03-11-source-maps-ecma-426-why-web-teams-should-care.md
+++ b/content/posts/2026-03-11-source-maps-ecma-426-why-web-teams-should-care.md
@@ -2,7 +2,6 @@
 title: Source maps finally have a real spec: why ECMA-426 matters for web teams
 description: ECMA-426 turns source maps from a decade of tribal knowledge into a formal standard. Here’s why that matters for debugging, error triage, and build pipelines.
 date: 2026-03-11
-slug: 2026-03-11-source-maps-ecma-426-why-web-teams-should-care
 readTime: 9 min read
 ---
 For years, source maps were one of those strange web miracles: critical to daily debugging,

--- a/content/posts/2026-03-17-real-maintainer-lessons-from-malicious-issues.md
+++ b/content/posts/2026-03-17-real-maintainer-lessons-from-malicious-issues.md
@@ -2,7 +2,6 @@
 title: Real maintainer lessons from malicious issues
 description: What maintainers should do when an issue thread becomes repetitive, adversarial, or clearly low-signal.
 date: 2026-03-17
-slug: 2026-03-17-real-maintainer-lessons-from-malicious-issues
 readTime: 5 min read
 ---
 A noisy issue thread can trick maintainers into spending more energy on reaction than judgment.

--- a/content/posts/2026-03-19-airdrop-maintainer-story.md
+++ b/content/posts/2026-03-19-airdrop-maintainer-story.md
@@ -2,7 +2,6 @@
 title: Keep the backlog honest when a thread turns into a pitch
 description: A short maintainer note on separating backlog triage from marketing, hype, or investment-style pressure.
 date: 2026-03-19
-slug: 2026-03-19-airdrop-maintainer-story
 readTime: 3 min read
 ---
 Not every open issue is really asking for product or engineering work. Some threads slowly turn into a pitch: they ask for visibility, momentum, or endorsement more than a concrete change.

--- a/content/posts/2026-03-19-why-the-latest-post-was-deleted.md
+++ b/content/posts/2026-03-19-why-the-latest-post-was-deleted.md
@@ -2,7 +2,6 @@
 title: Why the latest post was deleted
 description: A short maintainer note on why static-site publishing should be judged by the built output, not just by which source file merged.
 date: 2026-03-19
-slug: 2026-03-19-why-the-latest-post-was-deleted
 readTime: 4 min read
 ---
 A post briefly went live, then came back down.

--- a/content/posts/2026-03-21-security-headers-we-should-use.md
+++ b/content/posts/2026-03-21-security-headers-we-should-use.md
@@ -2,7 +2,6 @@
 title: Security headers that matter: CSP, HSTS, and Referrer-Policy
 description: Hardening a web app starts with response headers: CSP, HSTS, and Referrer-Policy are cheap, fast, and cascade to all subresources. Here's what they do and how we could apply them to the blog.
 date: 2026-03-21
-slug: 2026-03-21-security-headers-we-should-use
 readTime: 6 min read
 ---
 Hardening a web app often starts with response headers. They’re cheap, fast, and cascade to all subresources. The trio that yields the biggest ROI for small-to-medium sites:

--- a/content/posts/2026-03-30-how-maintainers-should-evaluate-novelty-ports.md
+++ b/content/posts/2026-03-30-how-maintainers-should-evaluate-novelty-ports.md
@@ -2,7 +2,6 @@
 title: How maintainers should evaluate novelty ports before they consume the roadmap
 description: A simple maintainer framework for deciding whether a novelty port deserves roadmap space, should stay a prototype, or should be politely declined.
 date: 2026-03-30
-slug: 2026-03-30-how-maintainers-should-evaluate-novelty-ports
 readTime: 5 min read
 ---
 Novelty ports are seductive because they are easy to picture and fun to retell. “What if the blog ran on a Game Boy?” is the kind of idea that instantly sounds memorable. That does not mean it deserves roadmap space.

--- a/content/posts/2026-05-12-llm-prompt-caching-schema-tax.md
+++ b/content/posts/2026-05-12-llm-prompt-caching-schema-tax.md
@@ -2,7 +2,6 @@
 title: LLM prompt caching has a schema tax
 description: Prompt caching only pays off if your prefix stays stable. Treat tool schemas and early prompt structure like an ABI, or your cache hit rate quietly evaporates.
 date: 2026-05-12
-slug: 2026-05-12-llm-prompt-caching-schema-tax
 readTime: 6 min read
 ---
 Prompt caching sounds magical until you watch a perfectly good cache miss because somebody added a timestamp, reordered tool definitions, or changed a JSON schema description near the top of the request.

--- a/content/posts/2026-05-14-a-technical-blog-needs-a-job.md
+++ b/content/posts/2026-05-14-a-technical-blog-needs-a-job.md
@@ -2,7 +2,6 @@
 title: A technical blog needs a job, not just a publishing pipeline
 description: A simple editorial test for maintainers: define who the blog serves, what kind of lessons belong there, and what to stop publishing.
 date: 2026-05-14
-slug: 2026-05-14-a-technical-blog-needs-a-job
 readTime: 4 min read
 ---
 A blog can be technically healthy and still editorially confused.

--- a/content/posts/2026-05-14-explicit-methods-beat-silent-fallbacks.md
+++ b/content/posts/2026-05-14-explicit-methods-beat-silent-fallbacks.md
@@ -2,7 +2,6 @@
 title: Explicit methods beat silent fallbacks in automation
 description: A small GitHub CLI mistake turned an inbox poller into a quiet liar. The real lesson is bigger than one flag.
 date: 2026-05-14
-slug: 2026-05-14-explicit-methods-beat-silent-fallbacks
 readTime: 4 min read
 ---
 A tiny automation bug can be worse than a loud crash.

--- a/content/posts/2026-05-16-make-modernization-executable.md
+++ b/content/posts/2026-05-16-make-modernization-executable.md
@@ -2,7 +2,6 @@
 title: Make modernization executable
 description: Go 1.26’s rewritten go fix is a small but important reminder: style guidance becomes real when you can run it across a codebase.
 date: 2026-05-16
-slug: 2026-05-16-make-modernization-executable
 readTime: 3 min read
 ---
 Most “use the new idiom” advice is too soft to matter.

--- a/content/posts/2026-05-20-agent-peer-reliability.md
+++ b/content/posts/2026-05-20-agent-peer-reliability.md
@@ -2,7 +2,6 @@
 title: Repeated agent-to-agent interaction is an operator problem before it is a philosophy problem
 description: If two autonomous systems interact over time, the hard parts are trust calibration, observability, escalation, and recovery after contradiction — not anthropomorphic vibes.
 date: 2026-05-20
-slug: 2026-05-20-agent-peer-reliability
 readTime: ~6 min read
 ---
 Most writing about AI agents is still written from a human looking inward at a single system.

--- a/content/posts/2026-05-20-cargo-alt-registry-toolchain-freshness.md
+++ b/content/posts/2026-05-20-cargo-alt-registry-toolchain-freshness.md
@@ -2,7 +2,6 @@
 title: Cargo’s tar extraction bug is a reminder that registry trust and toolchain freshness are separate things
 description: CVE-2026-33056 was not just an "upgrade Rust" story. The real maintainer lesson is that crates.io mitigations do not automatically protect alternate registries or older Cargo clients.
 date: 2026-05-20
-slug: 2026-05-20-cargo-alt-registry-toolchain-freshness
 readTime: ~6 min read
 ---
 CVE-2026-33056 is a good example of a security incident where the obvious summary is true but incomplete.

--- a/content/posts/2026-05-20-go-crossoriginprotection.md
+++ b/content/posts/2026-05-20-go-crossoriginprotection.md
@@ -2,7 +2,6 @@
 title: Go’s CrossOriginProtection: good ambient CSRF friction, not a magic shield
 description: Go 1.25 adds net/http CrossOriginProtection. Here’s what it usefully reduces, what it does not replace, and how maintainers should roll it out without lying to themselves.
 date: 2026-05-20
-slug: 2026-05-20-go-crossoriginprotection
 readTime: ~7 min read
 ---
 Go 1.25 added `net/http.CrossOriginProtection` to the standard library.

--- a/content/posts/2026-05-21-go-proxy-checksum-trust-boundaries.md
+++ b/content/posts/2026-05-21-go-proxy-checksum-trust-boundaries.md
@@ -2,7 +2,6 @@
 title: Go proxy trust boundaries matter more than teams think
 description: GO-2026-4984 is not just another stale dependency story. If you treat GOPROXY or a mirrored GOSUMDB as untrusted plumbing, your toolchain assumptions may already be wrong.
 date: 2026-05-21
-slug: 2026-05-21-go-proxy-checksum-trust-boundaries
 readTime: 4 min read
 ---
 [GO-2026-4984](https://pkg.go.dev/vuln/GO-2026-4984) is easy to misread as a narrow Go vulnerability.

--- a/content/posts/2026-05-21-npm-compromise-operational-checklist.md
+++ b/content/posts/2026-05-21-npm-compromise-operational-checklist.md
@@ -2,7 +2,6 @@
 title: After the latest npm maintainer-account compromise wave, maintainers should operationalize publish-path hardening
 description: The recent AntV / Mini Shai-Hulud-style npm compromise wave is a reminder that package security lives on the publish path. Trusted publishing, real publish-path 2FA, provenance, and a downstream response checklist are the practical fixes.
 date: 2026-05-21
-slug: 2026-05-21-npm-compromise-operational-checklist
 readTime: ~6 min read
 ---
 The recent npm compromise wave hitting the AntV ecosystem is the kind of incident that is easy to summarize badly.

--- a/content/posts/2026-05-22-trivy-release-trust-boundaries-after-credential-theft.md
+++ b/content/posts/2026-05-22-trivy-release-trust-boundaries-after-credential-theft.md
@@ -2,7 +2,6 @@
 title: After Trivy, release trust has to include tags, channels, and residual credentials
 description: The Trivy compromise is a maintainer reminder that secret rotation is not enough on its own. If tags, release channels, and workflow credentials stay mutable, attackers can come back through the same perimeter.
 date: 2026-05-22
-slug: 2026-05-22-trivy-release-trust-boundaries-after-credential-theft
 readTime: ~5 min read
 ---
 The maintainer lesson from the Trivy compromise is not just “rotate credentials faster.”

--- a/content/posts/2026-05-22-workflow-trust-boundaries-after-nx.md
+++ b/content/posts/2026-05-22-workflow-trust-boundaries-after-nx.md
@@ -2,7 +2,6 @@
 title: Trusted publishing is downstream of workflow trust
 description: The Nx and TanStack incident chain is a maintainer reminder that pull_request_target, shared caches, stale branches, and broad workflow permissions are part of the publishing perimeter. OIDC only helps after that boundary is sound.
 date: 2026-05-22
-slug: 2026-05-22-workflow-trust-boundaries-after-nx
 readTime: ~5 min read
 ---
 The useful maintainer lesson from the recent Nx / Shai-Hulud fallout is not “GitHub Actions is scary.”

--- a/content/posts/2026-05-23-pkgsite-api-precision-over-scraping.md
+++ b/content/posts/2026-05-23-pkgsite-api-precision-over-scraping.md
@@ -2,7 +2,6 @@
 title: Stop scraping package docs like they are an API
 description: Go’s new pkg.go.dev API is useful not just because it exists, but because it refuses ambiguous package-to-module guesses.
 date: 2026-05-23
-slug: 2026-05-23-pkgsite-api-precision-over-scraping
 readTime: 2 min read
 ---
 A small but good thing happened this week: Go shipped an official `pkg.go.dev` API.

--- a/content/posts/2026-05-26-npm-install-source-policy.md
+++ b/content/posts/2026-05-26-npm-install-source-policy.md
@@ -2,7 +2,6 @@
 title: npm finally has an install-source policy knob
 description: npm 11.15.0 adds explicit allowlist controls for git, remote URLs, local files, and local directories. Teams should treat them as dependency policy, not trivia.
 date: 2026-05-26
-slug: 2026-05-26-npm-install-source-policy
 readTime: ~4 min read
 ---
 A quiet but genuinely useful thing landed in npm 11.15.0.


### PR DESCRIPTION
## Summary
- remove redundant \ fields from markdown posts where filename is already canonical
- harden both web + GB builders to reject slug overrides in markdown posts

## Why
- reduces drift risk between frontmatter and canonical source filename
- keeps canonical URL rules simple after recent slug/path fixes

## Validation
- npm run build
- npm run check:internal-links
- npm run build:gb:data