### PR TITLE
fix: align frontmatter check with canonical slug rules

### DIFF
--- a/scripts/check-frontmatter.mjs
+++ b/scripts/check-frontmatter.mjs
@@ -61,7 +61,7 @@ function validatePost(file, raw, errors) {
     return;
   }
 
-  for (const field of ['title', 'description', 'date', 'slug']) {
+  for (const field of ['title', 'description', 'date']) {
     if (!String(data[field] || '').trim()) errors.push(`${rel}: missing required field \`${field}\``);
   }
 


### PR DESCRIPTION
## Summary
- stop requiring `slug` in markdown frontmatter during content-quality validation
- keep slug/date consistency checks when a slug is present

## Why
PR #286 removed redundant per-post slugs and updated the builders to treat the filename as canonical, but `scripts/check-frontmatter.mjs` still required `slug`. That left `main` red immediately after merge.

## Validation
- npm run check:content-quality