### PR TITLE
refactor: deduplicate post metadata validation

### DIFF
--- a/scripts/build-gb.mjs
+++ b/scripts/build-gb.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { parseFrontmatter, validatePostSourcePath } from './post-metadata.mjs';
 
 const root = process.cwd();
 const postsDir = path.join(root, 'content', 'posts');
@@ -9,45 +10,6 @@ const outSource = path.join(outDir, 'posts_data.c');
 
 const MAX_POSTS = 12;
 const MAX_BODY_CHARS = 1800;
-
-function parseFrontmatter(raw) {
-  if (!raw.startsWith('---\n')) return { data: {}, body: raw };
-  const end = raw.indexOf('\n---\n', 4);
-  if (end === -1) return { data: {}, body: raw };
-
-  const data = {};
-  const fm = raw.slice(4, end).trim();
-  for (const line of fm.split('\n')) {
-    const idx = line.indexOf(':');
-    if (idx === -1) continue;
-    const key = line.slice(0, idx).trim();
-    let value = line.slice(idx + 1).trim();
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
-    }
-    data[key] = value;
-  }
-
-  return { data, body: raw.slice(end + 5) };
-}
-
-function validatePostSourcePath(name, date, slug) {
-  const stem = name.replace(/\.md$/, '');
-  const match = stem.match(/^(\d{4}-\d{2}-\d{2})-/);
-  if (!match) {
-    throw new Error(`Invalid post source filename \"${name}\": expected content/posts/YYYY-MM-DD-slug.md`);
-  }
-  if (!date) {
-    throw new Error(`Post \"${name}\" is missing frontmatter date; expected it to match ${match[1]}`);
-  }
-  if (match[1] !== date) {
-    throw new Error(`Date mismatch for post \"${name}\": filename prefix is ${match[1]} but frontmatter date is ${date}`);
-  }
-  if (slug && slug !== stem) {
-    throw new Error(`Slug mismatch for post \"${name}\": frontmatter slug is ${slug} but canonical slug is ${stem}`);
-  }
-  return stem;
-}
 
 function markdownToPlainText(input) {
   let text = input.replace(/\r\n/g, '\n');

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { marked } from 'marked';
+import { parseFrontmatter, validatePostSourcePath } from './post-metadata.mjs';
 
 const root = process.cwd();
 const outDir = path.join(root, 'dist');
@@ -10,44 +11,6 @@ marked.setOptions({ gfm: true, breaks: false });
 
 function escapeHtml(s = '') {
   return s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
-}
-
-function parseFrontmatter(raw) {
-  if (!raw.startsWith('---\n')) return { data: {}, body: raw };
-  const end = raw.indexOf('\n---\n', 4);
-  if (end === -1) return { data: {}, body: raw };
-  const fm = raw.slice(4, end).trim();
-  const body = raw.slice(end + 5);
-  const data = {};
-  for (const line of fm.split('\n')) {
-    const idx = line.indexOf(':');
-    if (idx === -1) continue;
-    const key = line.slice(0, idx).trim();
-    let value = line.slice(idx + 1).trim();
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
-    }
-    data[key] = value;
-  }
-  return { data, body };
-}
-
-function validatePostSourcePath(name, date, slug) {
-  const stem = name.replace(/\.md$/, '');
-  const match = stem.match(/^(\d{4}-\d{2}-\d{2})-/);
-  if (!match) {
-    throw new Error(`Invalid post source filename \"${name}\": expected content/posts/YYYY-MM-DD-slug.md`);
-  }
-  if (!date) {
-    throw new Error(`Post \"${name}\" is missing frontmatter date; expected it to match ${match[1]}`);
-  }
-  if (match[1] !== date) {
-    throw new Error(`Date mismatch for post \"${name}\": filename prefix is ${match[1]} but frontmatter date is ${date}`);
-  }
-  if (slug && slug !== stem) {
-    throw new Error(`Slug mismatch for post \"${name}\": frontmatter slug is ${slug} but canonical slug is ${stem}`);
-  }
-  return stem;
 }
 
 function formatRssDate(dateStr) {

--- a/scripts/check-frontmatter.mjs
+++ b/scripts/check-frontmatter.mjs
@@ -1,29 +1,10 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isRealDate, parseFrontmatter, validatePostSourcePath } from './post-metadata.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(scriptDir, '..');
-
-function parseFrontmatter(raw) {
-  if (!raw.startsWith('---\n')) return { data: {}, body: raw, hasFrontmatter: false };
-  const end = raw.indexOf('\n---\n', 4);
-  if (end === -1) return { data: {}, body: raw, hasFrontmatter: false };
-  const fm = raw.slice(4, end).trim();
-  const body = raw.slice(end + 5);
-  const data = {};
-  for (const line of fm.split('\n')) {
-    const idx = line.indexOf(':');
-    if (idx === -1) continue;
-    const key = line.slice(0, idx).trim();
-    let value = line.slice(idx + 1).trim();
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
-    }
-    data[key] = value;
-  }
-  return { data, body, hasFrontmatter: true };
-}
 
 async function listMarkdownFiles(dir) {
   try {
@@ -35,20 +16,6 @@ async function listMarkdownFiles(dir) {
     if (error?.code === 'ENOENT') return [];
     throw error;
   }
-}
-
-function isIsoDate(value) {
-  return /^\d{4}-\d{2}-\d{2}$/.test(value);
-}
-
-function isRealDate(value) {
-  if (!isIsoDate(value)) return false;
-  const d = new Date(`${value}T00:00:00Z`);
-  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === value;
-}
-
-function expectedPostSlug(filename) {
-  return filename.replace(/\.md$/, '');
 }
 
 function validatePost(file, raw, errors) {
@@ -69,16 +36,10 @@ function validatePost(file, raw, errors) {
     errors.push(`${rel}: date must be a real ISO date (YYYY-MM-DD), got \`${data.date}\``);
   }
 
-  const expectedSlug = expectedPostSlug(name);
-  if (data.slug && data.slug !== expectedSlug) {
-    errors.push(`${rel}: slug must match filename \`${expectedSlug}\`, got \`${data.slug}\``);
-  }
-
-  const filenameDate = name.match(/^(\d{4}-\d{2}-\d{2})-/)?.[1];
-  if (!filenameDate) {
-    errors.push(`${rel}: filename must use YYYY-MM-DD-slug.md`);
-  } else if (data.date && data.date !== filenameDate) {
-    errors.push(`${rel}: date \`${data.date}\` does not match filename prefix \`${filenameDate}\``);
+  try {
+    validatePostSourcePath(name, data.date, data.slug);
+  } catch (error) {
+    errors.push(`${rel}: ${error.message}`);
   }
 
   if (!body.trim()) {

--- a/scripts/post-metadata.mjs
+++ b/scripts/post-metadata.mjs
@@ -1,0 +1,54 @@
+export function parseFrontmatter(raw) {
+  if (!raw.startsWith('---\n')) return { data: {}, body: raw, hasFrontmatter: false };
+  const end = raw.indexOf('\n---\n', 4);
+  if (end === -1) return { data: {}, body: raw, hasFrontmatter: false };
+
+  const fm = raw.slice(4, end).trim();
+  const body = raw.slice(end + 5);
+  const data = {};
+
+  for (const line of fm.split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    let value = line.slice(idx + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    data[key] = value;
+  }
+
+  return { data, body, hasFrontmatter: true };
+}
+
+export function expectedPostSlug(filename) {
+  return filename.replace(/\.md$/, '');
+}
+
+export function validatePostSourcePath(filename, date, slug) {
+  const stem = expectedPostSlug(filename);
+  const match = stem.match(/^(\d{4}-\d{2}-\d{2})-/);
+  if (!match) {
+    throw new Error(`Invalid post source filename \"${filename}\": expected content/posts/YYYY-MM-DD-slug.md`);
+  }
+  if (!date) {
+    throw new Error(`Post \"${filename}\" is missing frontmatter date; expected it to match ${match[1]}`);
+  }
+  if (match[1] !== date) {
+    throw new Error(`Date mismatch for post \"${filename}\": filename prefix is ${match[1]} but frontmatter date is ${date}`);
+  }
+  if (slug && slug !== stem) {
+    throw new Error(`Slug mismatch for post \"${filename}\": frontmatter slug is ${slug} but canonical slug is ${stem}`);
+  }
+  return stem;
+}
+
+export function isIsoDate(value) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+export function isRealDate(value) {
+  if (!isIsoDate(value)) return false;
+  const d = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === value;
+}


### PR DESCRIPTION
## Summary
- extract shared frontmatter parsing and canonical post source validation into `scripts/post-metadata.mjs`
- switch `build.mjs`, `build-gb.mjs`, and `check-frontmatter.mjs` to that shared source of truth
- keep the existing slug/date rules unchanged while removing the drift vector

## Checks
- `npm run check:frontmatter`
- `npm run build:gb:data`
- `npm run build`
- `npm run check:internal-links`

Closes #288.
