### PR TITLE
ci: include gb data build in content quality gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "node scripts/build.mjs",
     "check:frontmatter": "node scripts/check-frontmatter.mjs",
     "check:internal-links": "node scripts/check-internal-links.mjs",
-    "check:content-quality": "npm run check:frontmatter && npm run build && npm run check:internal-links",
+    "check:content-quality": "npm run check:frontmatter && npm run build:gb:data && npm run build && npm run check:internal-links",
     "build:gb:data": "node scripts/build-gb.mjs",
     "build:gb": "bash scripts/build-gb-rom.sh"
   },


### PR DESCRIPTION
## Summary
- run `npm run build:gb:data` inside the normal content-quality gate
- make the default local/CI content check exercise the Game Boy post dataset too

## Why now
Recent post-metadata fixes touched the site build, frontmatter lint, and Game Boy data path together. The repo already validates the full ROM build in the Pages workflow, but the lighter-weight content-quality gate still skipped the GB dataset surface entirely. That leaves a real drift gap in the faster default maintainer check.
