### PR TITLE
fix: show actionable GBDK error when lcc is missing

### DIFF
--- a/scripts/build-gb-rom.sh
+++ b/scripts/build-gb-rom.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 if [[ -z "${GBDKDIR:-}" ]]; then
-  lcc_path="$(command -v lcc)"
+  lcc_path="$(command -v lcc || true)"
   if [[ -z "${lcc_path}" ]]; then
-    echo "lcc not found in PATH" >&2
+    echo "lcc not found in PATH. Install GBDK-2020 and expose its bin directory (or set GBDKDIR)." >&2
     exit 1
   fi
   GBDKDIR="$(cd "$(dirname "${lcc_path}")/.." && pwd)"


### PR DESCRIPTION
## Summary
- stop `build-gb-rom.sh` from exiting before its own missing-compiler check under `set -e`
- show an actionable error that points maintainers to GBDK-2020 or `GBDKDIR`

## Testing
- `npm run check:content-quality`
- `bash scripts/build-gb-rom.sh` *(now fails with the intended error message when `lcc` is absent)*
