### PR TITLE
ci: route Pages validation through content quality gate

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate content and build site
+        run: npm run check:content-quality
+
       - name: Cache GBDK
         id: cache-gbdk
         uses: actions/cache@v5
@@ -60,12 +63,6 @@ jobs:
 
       - name: Build Game Boy ROM
         run: npm run build:gb
-
-      - name: Build site
-        run: npm run build
-
-      - name: Validate internal links
-        run: npm run check:internal-links
 
       - name: Upload ROM artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- make the Pages workflow call `npm run check:content-quality` for the common content/site validation path
- stop re-encoding the site build + internal link order directly in workflow YAML
- keep the ROM-specific GBDK and ROM build steps separate after the shared validation pass

Closes #295.
