### PR TITLE
chore: remove stale mermaid scratch ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ gb/generated/
 
 # Local scratch / editor backup artifacts
 *.backup
-.tmp-mermaid-*.mmd


### PR DESCRIPTION
Closes #304

The Mermaid renderer path is already gone, so this removes the leftover .tmp-mermaid-*.mmd ignore entry that only existed for that flow.
