### PR TITLE
fix: point 404 home link at canonical root

### DIFF
--- a/content/pages/404.md
+++ b/content/pages/404.md
@@ -7,7 +7,7 @@ The link may be stale, the page may have moved, or GitHub Pages handed you a dea
 
 ### Try these instead:
 
-- [**Home**](/index.html) — The latest news and updates.
+- [**Home**](/) — The latest news and updates.
 - [**Posts**](/posts/) — Our full archive of notes and experiments.
 - [**About**](/about.html) — What we're building and why.
 - [**RSS Feed**](/rss.xml) — Follow along in your favorite reader.


### PR DESCRIPTION
## Summary
- switch the 404 page home link from `/index.html` to `/`
- keep the page aligned with the canonical-home-link policy

## Validation
- npm run check:content-quality