### PR TITLE
ci: stop duplicate content-quality runs

### DIFF
--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -3,8 +3,6 @@ name: Content quality
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
   schedule:
     - cron: '17 3 * * *'
   workflow_dispatch:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,11 +3,6 @@ name: Build and deploy Pages
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-  schedule:
-    # Low-frequency health check so upstream dependency/toolchain drift fails before the next publish.
-    - cron: '17 3 * * 1,4'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,8 @@ name: Build and deploy Pages
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -33,8 +35,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Validate content and build site
-        run: npm run check:content-quality
+      - name: Build site assets for Pages
+        run: |
+          npm run build:gb:data
+          npm run build
 
       - name: Cache GBDK
         id: cache-gbdk


### PR DESCRIPTION
## Summary
- keep `Content quality` as the only full PR content gate
- keep the Pages `build` check on pull requests for branch protection
- make the Pages workflow build site assets without re-running the full `check:content-quality` chain

## Why
This preserves the required `build` status check while removing the duplicate `npm run check:content-quality` execution from the Pages workflow.

Closes #308