### PR TITLE
build: fail fast on malformed frontmatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   },
   "scripts": {
     "build": "node scripts/build.mjs",
+    "test": "node --test",
     "check:frontmatter": "node scripts/check-frontmatter.mjs",
     "check:internal-links": "node scripts/check-internal-links.mjs",
-    "check:content-quality": "npm run check:frontmatter && npm run build:gb:data && npm run build && npm run check:internal-links",
+    "check:content-quality": "npm test && npm run check:frontmatter && npm run build:gb:data && npm run build && npm run check:internal-links",
     "build:gb:data": "node scripts/build-gb.mjs",
     "build:gb": "bash scripts/build-gb-rom.sh"
   },

--- a/scripts/check-frontmatter.mjs
+++ b/scripts/check-frontmatter.mjs
@@ -21,7 +21,16 @@ async function listMarkdownFiles(dir) {
 function validatePost(file, raw, errors) {
   const rel = path.relative(root, file);
   const name = path.basename(file);
-  const { data, body, hasFrontmatter } = parseFrontmatter(raw);
+  let parsed;
+
+  try {
+    parsed = parseFrontmatter(raw);
+  } catch (error) {
+    errors.push(`${rel}: ${error.message}`);
+    return;
+  }
+
+  const { data, body, hasFrontmatter } = parsed;
 
   if (!hasFrontmatter) {
     errors.push(`${rel}: missing frontmatter block`);
@@ -49,7 +58,16 @@ function validatePost(file, raw, errors) {
 
 function validatePage(file, raw, errors) {
   const rel = path.relative(root, file);
-  const { data, body, hasFrontmatter } = parseFrontmatter(raw);
+  let parsed;
+
+  try {
+    parsed = parseFrontmatter(raw);
+  } catch (error) {
+    errors.push(`${rel}: ${error.message}`);
+    return;
+  }
+
+  const { data, body, hasFrontmatter } = parsed;
 
   if (!hasFrontmatter) {
     errors.push(`${rel}: missing frontmatter block`);

--- a/scripts/post-metadata.mjs
+++ b/scripts/post-metadata.mjs
@@ -1,21 +1,62 @@
+function unsupportedValueReason(value) {
+  if (value === '|' || value === '>') return 'block scalars are not supported';
+  if (value.startsWith('[') || value.startsWith('{')) return 'flow collections are not supported';
+  if (value.startsWith('&') || value.startsWith('*')) return 'anchors and aliases are not supported';
+  if (value.startsWith('!')) return 'tagged values are not supported';
+  return null;
+}
+
+function parseScalarValue(key, value, lineNumber) {
+  const unsupported = unsupportedValueReason(value);
+  if (unsupported) {
+    throw new Error(`Frontmatter line ${lineNumber}: field "${key}" uses unsupported YAML; ${unsupported}`);
+  }
+
+  if ((value.startsWith('"') && !value.endsWith('"')) || (value.startsWith("'") && !value.endsWith("'"))) {
+    throw new Error(`Frontmatter line ${lineNumber}: field "${key}" has an unterminated quoted value`);
+  }
+
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+}
+
 export function parseFrontmatter(raw) {
   if (!raw.startsWith('---\n')) return { data: {}, body: raw, hasFrontmatter: false };
   const end = raw.indexOf('\n---\n', 4);
   if (end === -1) return { data: {}, body: raw, hasFrontmatter: false };
 
-  const fm = raw.slice(4, end).trim();
+  const fm = raw.slice(4, end);
   const body = raw.slice(end + 5);
   const data = {};
+  const seenKeys = new Set();
 
-  for (const line of fm.split('\n')) {
-    const idx = line.indexOf(':');
-    if (idx === -1) continue;
-    const key = line.slice(0, idx).trim();
-    let value = line.slice(idx + 1).trim();
-    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
+  for (const [index, rawLine] of fm.split('\n').entries()) {
+    const lineNumber = index + 2;
+    const line = rawLine.trimEnd();
+
+    if (!line.trim()) continue;
+    if (/^\s/.test(rawLine)) {
+      throw new Error(`Frontmatter line ${lineNumber}: indented or multiline values are not supported`);
     }
-    data[key] = value;
+    if (line.startsWith('#')) {
+      throw new Error(`Frontmatter line ${lineNumber}: comments are not supported`);
+    }
+
+    const match = line.match(/^([A-Za-z0-9_-]+):(?:\s(.*)|\s*)$/);
+    if (!match) {
+      throw new Error(`Frontmatter line ${lineNumber}: expected "key: value"`);
+    }
+
+    const [, key, rawValue = ''] = match;
+    if (seenKeys.has(key)) {
+      throw new Error(`Frontmatter line ${lineNumber}: duplicate field "${key}"`);
+    }
+    seenKeys.add(key);
+
+    data[key] = parseScalarValue(key, rawValue, lineNumber);
   }
 
   return { data, body, hasFrontmatter: true };

--- a/test/post-metadata.test.mjs
+++ b/test/post-metadata.test.mjs
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseFrontmatter } from '../scripts/post-metadata.mjs';
+
+function load(raw) {
+  return parseFrontmatter(raw).data;
+}
+
+test('parses supported scalar frontmatter fields', () => {
+  const data = load(`---
+title: Hello
+slug: custom-slug
+description: "Quoted text"
+date: 2026-05-29
+readTime: ~5 min read
+---
+Body\n`);
+
+  assert.deepEqual(data, {
+    title: 'Hello',
+    slug: 'custom-slug',
+    description: 'Quoted text',
+    date: '2026-05-29',
+    readTime: '~5 min read'
+  });
+});
+
+test('rejects duplicate keys', () => {
+  assert.throws(
+    () => load(`---
+title: One
+title: Two
+---
+Body\n`),
+    /duplicate field "title"/
+  );
+});
+
+test('rejects malformed frontmatter lines', () => {
+  assert.throws(
+    () => load(`---
+title Hello
+---
+Body\n`),
+    /expected "key: value"/
+  );
+});
+
+test('rejects block scalars and indented multiline values', () => {
+  assert.throws(
+    () => load(`---
+description: |
+  multiline
+---
+Body\n`),
+    /block scalars are not supported/
+  );
+
+  assert.throws(
+    () => load(`---
+description: first line
+  second line
+---
+Body\n`),
+    /indented or multiline values are not supported/
+  );
+});
+
+test('rejects comments and other unsupported yaml features', () => {
+  assert.throws(
+    () => load(`---
+# note
+title: Hello
+---
+Body\n`),
+    /comments are not supported/
+  );
+
+  assert.throws(
+    () => load(`---
+tags: [one, two]
+---
+Body\n`),
+    /flow collections are not supported/
+  );
+});


### PR DESCRIPTION
## Summary
- make `parseFrontmatter()` reject malformed or unsupported YAML instead of silently skipping it
- detect duplicate keys and surface clear line-numbered errors during content validation/builds
- add parser tests and run them in `check:content-quality`

## Why
Issue #310 is about stopping metadata drift from quietly publishing bad output. For this repo, loud failure is much safer than permissive parsing.

## Validation
- `npm test`
- `npm run check:frontmatter`
- `npm run build`
- `npm run check:internal-links`

Closes #310