### PR TITLE
ci: re-check content rules before main deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,6 +40,13 @@ jobs:
           npm run build:gb:data
           npm run build
 
+      - name: Re-check content rules before main deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          npm test
+          npm run check:frontmatter
+          npm run check:internal-links
+
       - name: Cache GBDK
         id: cache-gbdk
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary
- keep the full `Content quality` gate on pull requests
- add a lightweight main-only re-check in the Pages workflow before deploy
- cover direct pushes/admin merges without restoring duplicate PR validation

## Why
After #309, merged code on `main` still built and deployed, but the stricter test/frontmatter/internal-link checks only ran on pull requests, schedule, or manual dispatch. This restores a last safety pass on deploy-bound pushes without bringing back the old duplicate PR content-quality run.

## Validation
- npm test
- npm run check:frontmatter
- npm run build:gb:data
- npm run build
- npm run check:internal-links