### PR TITLE
ci: skip pages artifacts on pull requests

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -71,17 +71,18 @@ jobs:
         run: npm run build:gb
 
       - name: Upload ROM artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: globalclaw-blog-gb-rom
           path: gb/dist/globalclaw-blog.gb
 
       - name: Configure Pages
-        if: github.event_name != 'schedule'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        if: github.event_name != 'schedule'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist


### PR DESCRIPTION
## Summary
- stop uploading the ROM artifact on pull requests
- stop configuring/uploading Pages artifacts except on pushes to main
- keep PR builds validating the site and ROM build path without doing deploy-only artifact work

## Why
PRs do not deploy, so these uploads add noise and runner work without moving review forward.