### PR TITLE
docs: tighten off-topic issue triage policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,21 @@ Follow `SECURITY.md` instead.
 Be kind, be specific, and include reproduction steps for site issues.
 Low-context or low-signal requests may be closed quickly to keep the backlog clean.
 Repeat low-signal issue patterns may also be locked after closure so maintainers can stay focused on actual content and concrete site bugs.
+
+## Fast-close policy for off-topic threads
+Issues that are primarily any of the following will usually be closed immediately and may be locked if the pattern repeats:
+- roleplay, persona, or "post as a character" prompts
+- social bait, manipulation, or attempts to turn the tracker into a conversation venue
+- guest-post pitches with no concrete technical topic or reader value
+- vague meme/joke threads with no actionable blog/site outcome
+- requests for personal, private, or identifying information
+
+The tracker is for actionable blog work: real bugs, concrete content ideas, and small majority-value improvements.
+
+## Maintainer triage default
+When an issue is clearly out of scope, maintainers should prefer a short, consistent response:
+1. close quickly
+2. use a plain reason tied to repo scope
+3. lock when the thread is repetitive, bait-y, or likely to restart the same non-actionable pattern
+
+Default stance: do not argue at length inside the issue tracker. Keep the lane clean and move on.

--- a/POSTING_RULES.md
+++ b/POSTING_RULES.md
@@ -60,3 +60,9 @@ These rules are **mandatory** for any new post and for maintainer decisions.
 
 ## 10) Publishing
 - Posts may be published on maintainers’ own initiative when we learn interesting developer things.
+
+## 11) Tracker hygiene
+- The issue tracker is for actionable blog/site work, not free-form conversation.
+- Off-topic issue threads may be closed immediately.
+- Repeated low-signal, manipulative, or roleplay-style issue threads may be locked after closure.
+- Maintainers should prefer short, consistent closures over extended back-and-forth on obviously out-of-scope threads.


### PR DESCRIPTION
## Summary
- clarify a fast-close policy for off-topic / roleplay / manipulative issue threads
- document the default maintainer triage stance for short close + optional lock
- add a small tracker-hygiene rule to posting rules

## Why
Recent issue noise showed that forms alone do not keep the tracker in shape. This keeps the response lightweight and consistent without turning moderation into a big side project.

Closes #320