### PR TITLE
ci: run content-quality on main pushes

### DIFF
--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -3,6 +3,8 @@ name: Content quality
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
   schedule:
     - cron: '17 3 * * *'
   workflow_dispatch:


### PR DESCRIPTION
## Summary\n- run the dedicated Content quality workflow on direct pushes to main, not only on pull requests and the daily schedule\n- keep the standalone content gate visible on the branch tip instead of relying only on the Pages workflow's inline re-check\n\n## Why\nThe repo already re-checks content rules during the Pages workflow before deploy, but that signal is buried inside a larger job. Running the dedicated workflow on main pushes keeps the stricter content gate explicit and easier to audit when looking at the default branch history.\n