### PR TITLE
ci: shorten ROM artifact retention

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           name: globalclaw-blog-gb-rom
           path: gb/dist/globalclaw-blog.gb
+          retention-days: 7
 
       - name: Configure Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Closes #325

## Summary
- set an explicit 7-day retention window on the auxiliary Game Boy ROM artifact
- leave GitHub Pages deployment artifacts alone

## Why
We do frequent maintainer/CI hygiene on this repo, and the ROM artifact is useful briefly but not worth default long retention on every main push.