### PR TITLE
ci: add content-quality concurrency guard

### DIFF
--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: content-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-content:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a workflow-level concurrency guard to `Content quality`
- cancel stale in-progress runs for the same ref
- align the workflow with the existing concurrency pattern used by `pages.yml` and `codeql.yml`

Closes #327.
