### PR TITLE
ci: stop running Pages build on pull requests

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,8 +3,6 @@ name: Build and deploy Pages
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Closes #331

Pages never deploys from pull requests, and content-quality already validates the build path there. This trims duplicate CI without weakening the guardrails we actually care about.