### PR TITLE
ci: gate Pages deploy on content-quality

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,9 @@
 name: Build and deploy Pages
 
 on:
-  push:
+  workflow_run:
+    workflows: ['Content quality']
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -9,16 +11,19 @@ permissions:
   contents: read
 
 concurrency:
-  group: pages-${{ github.ref }}
+  group: pages-${{ github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   build:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -34,25 +39,16 @@ jobs:
           npm run build:gb:data
           npm run build
 
-      - name: Re-check content rules before main deploy
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          npm test
-          npm run check:frontmatter
-          npm run check:internal-links
-
       - name: Configure Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: ./dist
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 10
     permissions:
       pages: write


### PR DESCRIPTION
## Summary
- trigger Pages deploy from successful `Content quality` runs on `main`
- remove the duplicated content re-check from the Pages workflow
- check out the exact validated `head_sha` before building deploy artifacts

## Testing
- npm run check:content-quality

Closes #333.
