### PR TITLE
ci: avoid scheduled no-op Pages deploys

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,12 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push'
+      )
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +53,12 @@ jobs:
           path: ./dist
 
   deploy:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push'
+      )
     timeout-minutes: 10
     permissions:
       pages: write


### PR DESCRIPTION
## Summary
- gate Pages builds/deploys so only successful push-driven `Content quality` runs trigger publish
- keep `workflow_dispatch` available for explicit maintainer deploys
- stop nightly scheduled validation from causing no-op Pages redeploys

Closes #337.
