### PR TITLE
ci: stop creating skipped Pages runs after scheduled validation

### DIFF
--- a/.github/workflows/content-quality-main.yml
+++ b/.github/workflows/content-quality-main.yml
@@ -1,17 +1,14 @@
-name: Content quality
+name: Content quality (main)
 
 on:
-  pull_request:
+  push:
     branches: [main]
-  schedule:
-    - cron: '17 3 * * *'
-  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: content-quality-${{ github.workflow }}-${{ github.ref }}
+  group: content-quality-main-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Build and deploy Pages
 
 on:
   workflow_run:
-    workflows: ['Content quality']
+    workflows: ['Content quality (main)']
     types: [completed]
     branches: [main]
   workflow_dispatch:
@@ -18,10 +18,7 @@ jobs:
   build:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push'
-      )
+      github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
@@ -55,10 +52,7 @@ jobs:
   deploy:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push'
-      )
+      github.event.workflow_run.conclusion == 'success'
     timeout-minutes: 10
     permissions:
       pages: write


### PR DESCRIPTION
## Summary
- move main-branch push validation into a dedicated `Content quality (main)` workflow
- keep the existing `Content quality` workflow focused on pull requests, schedule, and manual runs
- make Pages listen only to the new push-only workflow so scheduled validation no longer creates skipped deploy runs

## Testing
- npm run check:content-quality
