### PR TITLE
ci: stop running Game Boy ROM workflow on unrelated main pushes

### DIFF
--- a/.github/workflows/game-boy-rom.yml
+++ b/.github/workflows/game-boy-rom.yml
@@ -3,6 +3,13 @@ name: Build Game Boy ROM
 on:
   push:
     branches: [main]
+    paths:
+      - '.github/workflows/game-boy-rom.yml'
+      - 'content/posts/**'
+      - 'gb/**'
+      - 'package-lock.json'
+      - 'package.json'
+      - 'scripts/**'
   schedule:
     - cron: '41 2 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Closes #342

## Summary
- limit the ROM workflow's `main` push trigger to files that can affect ROM output
- keep the nightly scheduled run and manual dispatch path unchanged
- leave routine site-only main pushes free of unnecessary ROM builds

## Testing
- npm test
