### PR TITLE
ci: stop running CodeQL on content-only main pushes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,14 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    paths:
+      - 'assets/js/**'
+      - 'gb/**'
+      - 'scripts/**'
+      - 'test/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/codeql.yml'
   pull_request:
     branches: [main]
   schedule:


### PR DESCRIPTION
Closes #344.

## Summary
- narrow CodeQL main-push runs to code-relevant paths
- keep PR, scheduled, and manual CodeQL coverage unchanged
- avoid branch-tip CodeQL noise for content-only publishes
