### PR TITLE
ci: stop running CodeQL on content-only pull requests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,14 @@ on:
       - '.github/workflows/codeql.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'assets/js/**'
+      - 'gb/**'
+      - 'scripts/**'
+      - 'test/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/codeql.yml'
   schedule:
     - cron: '29 4 * * 1'
   workflow_dispatch:


### PR DESCRIPTION
Closes #346.

## What changed
- added the same relevant file filters to the `pull_request` trigger in `codeql.yml`
- kept scheduled and manual CodeQL runs unchanged

## Why
Content-only PRs cannot affect the JavaScript/build codepaths that CodeQL analyzes, so this trims unnecessary CI noise and minutes without weakening the targeted checks.
