### PR TITLE
ci: scope main deploy gate to site-affecting changes

### DIFF
--- a/.github/workflows/content-quality-main.yml
+++ b/.github/workflows/content-quality-main.yml
@@ -3,6 +3,17 @@ name: Content quality (main)
 on:
   push:
     branches: [main]
+    paths:
+      - '.github/workflows/content-quality-main.yml'
+      - '.github/workflows/pages.yml'
+      - 'CNAME'
+      - 'assets/**'
+      - 'content/**'
+      - 'gb/**'
+      - 'package-lock.json'
+      - 'package.json'
+      - 'scripts/**'
+      - 'test/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- add a `paths` filter to `Content quality (main)`
- keep the main-push Pages handoff limited to site-affecting inputs
- stop README / repo-docs-only pushes from burning the full validate+deploy chain

Closes #348.

## Testing
- npm run check:content-quality
