### PR TITLE
ci: scope PR content-quality to site-affecting changes

### DIFF
--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -3,6 +3,16 @@ name: Content quality
 on:
   pull_request:
     branches: [main]
+    paths:
+      - '.github/workflows/content-quality.yml'
+      - 'CNAME'
+      - 'assets/**'
+      - 'content/**'
+      - 'gb/**'
+      - 'package-lock.json'
+      - 'package.json'
+      - 'scripts/**'
+      - 'test/**'
   schedule:
     - cron: '17 3 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Closes #351

Align the PR-side `Content quality` trigger with the already-tightened main-push scope so repo-only documentation and maintainer-process changes do not spend CI on a full site validation run.