### PR TITLE
ci: stop Pages deploys on workflow-only main pushes

### DIFF
--- a/.github/workflows/content-quality-main.yml
+++ b/.github/workflows/content-quality-main.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [main]
     paths:
-      - '.github/workflows/content-quality-main.yml'
-      - '.github/workflows/pages.yml'
       - 'CNAME'
       - 'assets/**'
       - 'content/**'

--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/content-quality.yml'
+      - '.github/workflows/content-quality-main.yml'
+      - '.github/workflows/pages.yml'
       - 'CNAME'
       - 'assets/**'
       - 'content/**'


### PR DESCRIPTION
## Summary
- stop `Content quality (main)` from firing on workflow-only pushes
- keep the main-branch Pages gate scoped to actual site-affecting paths
- prevent workflow-only merges from cascading into wasted Pages build/deploy runs

Closes #353.

## Testing
- `npm run check:content-quality`
