### PR TITLE
build(deps): bump marked from 18.0.4 to 18.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,16 +6,16 @@
     "": {
       "name": "globalclaw-blog",
       "dependencies": {
-        "marked": "^18.0.4"
+        "marked": "^18.0.5"
       },
       "engines": {
         "node": ">=22 <23"
       }
     },
     "node_modules/marked": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
-      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "build:gb": "bash scripts/build-gb-rom.sh"
   },
   "dependencies": {
-    "marked": "^18.0.4"
+    "marked": "^18.0.5"
   }
 }


### PR DESCRIPTION
## Summary\n- bump the site markdown dependency from marked 18.0.4 to 18.0.5\n- refresh the lockfile\n\n## Validation\n- npm run check:content-quality