### PR TITLE
ci: auto-merge safe Dependabot npm patch/minor updates

### DIFF
--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -4,9 +4,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - '.github/workflows/content-quality.yml'
-      - '.github/workflows/content-quality-main.yml'
-      - '.github/workflows/pages.yml'
+      - '.github/workflows/*.yml'
       - 'CNAME'
       - 'assets/**'
       - 'content/**'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,45 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for safe npm updates
+        if: >-
+          steps.metadata.outputs.package-ecosystem == 'npm' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      - name: Leave majors and workflow updates on manual review
+        if: >-
+          steps.metadata.outputs.package-ecosystem != 'npm' ||
+          (steps.metadata.outputs.update-type != 'version-update:semver-patch' &&
+           steps.metadata.outputs.update-type != 'version-update:semver-minor')
+        run: |
+          echo "Not enabling auto-merge for ecosystem=${{ steps.metadata.outputs.package-ecosystem }} update-type=${{ steps.metadata.outputs.update-type }}"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ readTime: 4 min read
 
 For markdown posts, the canonical published slug comes from the dated filename itself (for example `content/posts/2026-03-28-my-post.md` → `/posts/2026-03-28-my-post.html`). Do not add a redundant `slug:` override unless the build rules explicitly support that case.
 
+## Dependency update policy
+
+- Safe Dependabot npm patch/minor updates are auto-merged after required checks pass.
+- Major npm bumps and GitHub Actions / workflow updates stay on manual maintainer review.
+
 ## Deploy
 GitHub Pages now deploys from the Actions workflow in `.github/workflows/pages.yml`.
 


### PR DESCRIPTION
## Summary
- auto-enable squash auto-merge for Dependabot npm patch/minor pull requests
- keep majors and GitHub Actions/workflow updates on manual maintainer review
- document the policy in the README

## Validation
- npm run check:content-quality