### PR TITLE
ci: narrow content-quality PR trigger

### DIFF
--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - '.github/workflows/*.yml'
+      - '.github/workflows/content-quality.yml'
       - 'CNAME'
       - 'assets/**'
       - 'content/**'


### PR DESCRIPTION
## Summary
- stop PR-side Content quality from triggering on unrelated workflow-only changes
- keep the workflow self-triggering when its own definition changes

## Testing
- not run locally (workflow-path change only)

Closes #358