### PR TITLE
ci: restore PR validation for main/pages workflow edits

### DIFF
--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/content-quality.yml'
+      - '.github/workflows/content-quality-main.yml'
+      - '.github/workflows/pages.yml'
       - 'CNAME'
       - 'assets/**'
       - 'content/**'


### PR DESCRIPTION
## Summary
- restore PR-side `Content quality` coverage for `.github/workflows/content-quality-main.yml`
- restore PR-side `Content quality` coverage for `.github/workflows/pages.yml`
- keep the broader workflow-trigger narrowing intact

Closes #360.

## Testing
- `npm run check:content-quality`
