### PR TITLE
ci: narrow Game Boy ROM push trigger

### DIFF
--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/content-quality.yml'
       - '.github/workflows/content-quality-main.yml'
+      - '.github/workflows/game-boy-rom.yml'
       - '.github/workflows/pages.yml'
       - 'CNAME'
       - 'assets/**'

--- a/.github/workflows/game-boy-rom.yml
+++ b/.github/workflows/game-boy-rom.yml
@@ -7,9 +7,9 @@ on:
       - '.github/workflows/game-boy-rom.yml'
       - 'content/posts/**'
       - 'gb/**'
-      - 'package-lock.json'
-      - 'package.json'
-      - 'scripts/**'
+      - 'scripts/build-gb-rom.sh'
+      - 'scripts/build-gb.mjs'
+      - 'scripts/post-metadata.mjs'
   schedule:
     - cron: '41 2 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Closes #362.

## Summary
- stop watching generic package manifest changes for the ROM workflow
- keep ROM builds on actual ROM/content changes
- watch only the ROM-specific scripts the workflow actually uses