### PR TITLE
ci: scope Dependabot auto-merge trigger

### DIFF
--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/content-quality.yml'
       - '.github/workflows/content-quality-main.yml'
+      - '.github/workflows/dependabot-auto-merge.yml'
       - '.github/workflows/game-boy-rom.yml'
       - '.github/workflows/pages.yml'
       - 'CNAME'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,6 +2,11 @@ name: Dependabot auto-merge
 
 on:
   pull_request_target:
+    branches: [main]
+    paths:
+      - '.github/workflows/dependabot-auto-merge.yml'
+      - 'package.json'
+      - 'package-lock.json'
     types:
       - opened
       - synchronize


### PR DESCRIPTION
## Summary
- restrict the Dependabot auto-merge workflow to PRs targeting `main`
- only trigger it for npm manifest changes or edits to the workflow itself
- avoid unnecessary `pull_request_target` runs on unrelated PRs

## Why
The workflow only performs useful work for Dependabot npm update PRs. Letting it wake up for unrelated pull requests adds needless privileged workflow executions without improving review coverage.