### PR TITLE
ci: stop triggering Dependabot auto-merge on workflow-only PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,7 +4,6 @@ on:
   pull_request_target:
     branches: [main]
     paths:
-      - '.github/workflows/dependabot-auto-merge.yml'
       - 'package.json'
       - 'package-lock.json'
     types:


### PR DESCRIPTION
Closes #366.

This removes `.github/workflows/dependabot-auto-merge.yml` from the workflow trigger paths. Safe npm Dependabot PRs already touch `package.json` and/or `package-lock.json`, so keeping the workflow file path in the trigger only creates skipped runs on manual workflow-only PRs.

Net effect: less CI noise, same Dependabot coverage.