### PR TITLE
content: add Cargo registry identity note

### DIFF
--- a/content/posts/2026-06-06-cargo-registry-identity-is-an-auth-boundary.md
+++ b/content/posts/2026-06-06-cargo-registry-identity-is-an-auth-boundary.md
@@ -1,0 +1,54 @@
+---
+title: Cargo registry identity is an auth boundary
+description: A recent Cargo advisory is a good reminder that registry URL normalization is not harmless plumbing. In package managers, naming rules can decide where credentials leak.
+date: 2026-06-06
+readTime: 3 min read
+---
+A nice small supply-chain lesson landed in Rust 1.96.0, and it is broader than Rust.
+
+Cargo fixed a bug where sparse registry URLs were normalized too aggressively: a registry at `https://example.com/index` could be treated as equivalent to `https://example.com/index.git`, even though HTTPS servers are free to treat those as different locations.
+
+Under narrow but real conditions, that meant a victim’s Cargo token could be sent to the wrong registry.
+
+That bug is tracked as **CVE-2026-5222**.
+
+## The useful lesson
+In package infrastructure, **registry identity is part of the authentication boundary**.
+
+That sounds obvious when stated plainly.
+But toolchains often inherit URL-normalization habits from older backends, convenience layers, or “these usually point to the same thing” assumptions.
+
+Those assumptions are fine right up until credentials are attached.
+
+Cargo’s advisory explains the root cause well:
+
+- git-backed registry handling historically treated `.git` suffixes as interchangeable
+- sparse registries later reused that normalization
+- ordinary HTTPS hosting does **not** guarantee those URLs represent the same authority
+- once Cargo reused credentials across that boundary, the naming shortcut became a security bug
+
+That is the pattern worth remembering.
+
+## The maintainer takeaway
+If your tooling talks to registries, mirrors, artifact stores, or package indexes, treat these as security questions, not string-cleanup trivia:
+
+- Which exact URL defines registry identity?
+- Which transformations are safe only for one protocol, but not another?
+- Are credentials keyed by canonical identity, or by a lossy heuristic?
+- Can one host expose multiple independently controlled registries under similar-looking paths?
+
+The interesting part is not “Cargo had a bug.”
+It is that **identity normalization and auth reuse are the same design surface** whether you are building a package manager, an internal proxy, or CI glue around one.
+
+## Tiny checklist
+If you own dependency infrastructure, I would check this:
+
+- Are credentials scoped to exact registry identities?
+- Do we inherit URL normalization rules from git or another protocol where they do not belong?
+- Can similarly named endpoints on one domain be controlled by different actors?
+- Have we tested the weird path-suffix cases, not just the happy path?
+
+Convenience normalization is cheap.
+Credential boundaries are not.
+
+Sources: Rust’s `Security Advisory for Cargo (CVE-2026-5222)` from 2026-05-25 and the Rust 1.96.0 release notes from 2026-05-28.


### PR DESCRIPTION
## Summary
- add a short weekend post based on Rust's Cargo advisory CVE-2026-5222
- focus the lesson on registry identity as part of the authentication boundary
- keep it practical and source-grounded rather than commentary-driven

## Testing
- npm run check:content-quality