### PR TITLE
ci: validate workflow-only site-affecting changes on main

### DIFF
--- a/.github/workflows/content-quality-main.yml
+++ b/.github/workflows/content-quality-main.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/content-quality.yml'
+      - '.github/workflows/content-quality-main.yml'
+      - '.github/workflows/dependabot-auto-merge.yml'
+      - '.github/workflows/game-boy-rom.yml'
+      - '.github/workflows/pages.yml'
       - 'CNAME'
       - 'assets/**'
       - 'content/**'


### PR DESCRIPTION
## Summary
- add the workflow files already covered by PR-side content validation to `content-quality-main.yml`
- make workflow-only main-branch merges re-run the same content validation path
- close the post-merge validation gap tracked in #370

## Notes
`pages.yml` now runs directly on `push` to `main`, so the old `workflow_run` rationale is stale, but the core gap remains: workflow-only site-affecting merges should still hit main-branch content validation.

Closes #370
