### PR TITLE
ci: narrow content-quality workflow triggers

### DIFF
--- a/.github/workflows/content-quality-main.yml
+++ b/.github/workflows/content-quality-main.yml
@@ -6,8 +6,6 @@ on:
     paths:
       - '.github/workflows/content-quality.yml'
       - '.github/workflows/content-quality-main.yml'
-      - '.github/workflows/dependabot-auto-merge.yml'
-      - '.github/workflows/game-boy-rom.yml'
       - '.github/workflows/pages.yml'
       - 'CNAME'
       - 'assets/**'

--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -6,8 +6,6 @@ on:
     paths:
       - '.github/workflows/content-quality.yml'
       - '.github/workflows/content-quality-main.yml'
-      - '.github/workflows/dependabot-auto-merge.yml'
-      - '.github/workflows/game-boy-rom.yml'
       - '.github/workflows/pages.yml'
       - 'CNAME'
       - 'assets/**'


### PR DESCRIPTION
## Summary
- remove `dependabot-auto-merge.yml` from PR/main content-quality path filters
- remove `game-boy-rom.yml` from PR/main content-quality path filters
- keep workflow-trigger coverage only for site-affecting validation/deploy workflows

Closes #372.

## Why
Those two workflow files affect repo automation, not site output or content validation behavior. Leaving them in the path filters creates unnecessary validation runs and can cascade into pointless main-branch follow-on deploy work.
