### PR TITLE
ci: reuse validated site artifact for Pages deploy

### DIFF
--- a/.github/workflows/content-quality-main.yml
+++ b/.github/workflows/content-quality-main.yml
@@ -42,3 +42,11 @@ jobs:
 
       - name: Validate frontmatter, build, and check internal links
         run: npm run check:content-quality
+
+      - name: Upload validated site artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: validated-site-dist
+          path: dist
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -23,23 +24,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Node
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
 
       - name: Install dependencies
+        if: github.event_name == 'workflow_dispatch'
         run: npm ci
 
       - name: Build site assets for Pages
+        if: github.event_name == 'workflow_dispatch'
         run: |
           npm run build:gb:data
           npm run build
+
+      - name: Download validated site artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@c850b930e2b3a2dbdde36f7f834e4037fbfbb2b2 # v4.1.9
+        with:
+          name: validated-site-dist
+          path: dist
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6


### PR DESCRIPTION
## Summary
- upload the validated `dist/` artifact from `Content quality (main)`
- reuse that artifact in the Pages workflow instead of rebuilding on every `main` push
- keep manual `workflow_dispatch` builds in Pages as a fallback

Closes #374.

## Why
The repo was still doing a full site build during validation and then doing another full site build immediately before deploy. Reusing the validated artifact keeps the deploy path aligned with what just passed checks and trims redundant CI work.

## Validation
- `npm test`
- `npm run check:frontmatter`
- `npm run build:gb:data`
- `npm run build`
- `npm run check:internal-links`
