### PR TITLE
ci: fix Pages artifact download action pin

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Download validated site artifact
         if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@c850b930e2b3a2dbdde36f7f834e4037fbfbb2b2 # v4.1.9
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: validated-site-dist
           path: dist


### PR DESCRIPTION
## Summary
- fix the pinned `actions/download-artifact` SHA in `pages.yml`
- keep the intended `v4.1.9` version while pointing at the real commit
- restore Pages deploys triggered from `Content quality (main)`

## Why
The latest `Build and deploy Pages` run on `main` failed during job setup because the workflow referenced a nonexistent `actions/download-artifact` commit SHA, so the deploy never started.

## Testing
- workflow-only change should trigger `Content quality` on the PR
- merge should restore the downstream `Build and deploy Pages` path on `main`