### PR TITLE
ci: validate manual Pages dispatches

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,11 +38,9 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: npm ci
 
-      - name: Build site assets for Pages
+      - name: Validate content and build site assets
         if: github.event_name == 'workflow_dispatch'
-        run: |
-          npm run build:gb:data
-          npm run build
+        run: npm run check:content-quality
 
       - name: Download validated site artifact
         if: github.event_name == 'workflow_run'


### PR DESCRIPTION
## Summary
- make workflow_dispatch run the same content validation command used for trusted site builds
- keep the existing validated-artifact reuse path for Content quality (main) driven deploys
- close the manual deploy footgun where unchecked content could be published

Closes #379