### PR TITLE
ci: run Game Boy ROM build on relevant PRs

### DIFF
--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/content-quality.yml'
       - '.github/workflows/content-quality-main.yml'
+      - '.github/workflows/game-boy-rom.yml'
       - '.github/workflows/pages.yml'
       - 'CNAME'
       - 'assets/**'

--- a/.github/workflows/game-boy-rom.yml
+++ b/.github/workflows/game-boy-rom.yml
@@ -3,13 +3,15 @@ name: Build Game Boy ROM
 on:
   push:
     branches: [main]
-    paths:
+    paths: &rom_paths
       - '.github/workflows/game-boy-rom.yml'
       - 'content/posts/**'
       - 'gb/**'
       - 'scripts/build-gb-rom.sh'
       - 'scripts/build-gb.mjs'
       - 'scripts/post-metadata.mjs'
+  pull_request:
+    paths: *rom_paths
   schedule:
     - cron: '41 2 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Closes #381.

## Summary
- add a pull_request trigger to the Game Boy ROM workflow
- reuse the same path filter already used for pushes to main
- keep non-ROM PRs from paying for the extra build job