### PR TITLE
ci: codify workflow trigger policy

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'assets/js/**'
+      - 'config/workflow-trigger-policy.json'
       - 'gb/**'
       - 'scripts/**'
       - 'test/**'
@@ -15,6 +16,7 @@ on:
     branches: [main]
     paths:
       - 'assets/js/**'
+      - 'config/workflow-trigger-policy.json'
       - 'gb/**'
       - 'scripts/**'
       - 'test/**'
@@ -64,6 +66,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
+
+      - name: Check workflow trigger policy
+        run: npm run check:workflow-trigger-policy
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/content-quality-main.yml
+++ b/.github/workflows/content-quality-main.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/pages.yml'
       - 'CNAME'
       - 'assets/**'
+      - 'config/workflow-trigger-policy.json'
       - 'content/**'
       - 'gb/**'
       - 'package-lock.json'

--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/pages.yml'
       - 'CNAME'
       - 'assets/**'
+      - 'config/workflow-trigger-policy.json'
       - 'content/**'
       - 'gb/**'
       - 'package-lock.json'

--- a/.github/workflows/game-boy-rom.yml
+++ b/.github/workflows/game-boy-rom.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths: &rom_paths
       - '.github/workflows/game-boy-rom.yml'
+      - 'config/workflow-trigger-policy.json'
       - 'content/posts/**'
       - 'gb/**'
       - 'scripts/build-gb-rom.sh'
@@ -40,6 +41,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
+
+      - name: Check workflow trigger policy
+        run: npm run check:workflow-trigger-policy
 
       - name: Install dependencies
         run: npm ci

--- a/config/workflow-trigger-policy.json
+++ b/config/workflow-trigger-policy.json
@@ -1,0 +1,152 @@
+{
+  "workflows": [
+    {
+      "id": "content-quality",
+      "file": ".github/workflows/content-quality.yml",
+      "events": {
+        "pull_request": [
+          ".github/workflows/content-quality.yml",
+          ".github/workflows/content-quality-main.yml",
+          ".github/workflows/game-boy-rom.yml",
+          ".github/workflows/pages.yml",
+          "CNAME",
+          "assets/**",
+          "config/workflow-trigger-policy.json",
+          "content/**",
+          "gb/**",
+          "package-lock.json",
+          "package.json",
+          "scripts/**",
+          "test/**"
+        ]
+      }
+    },
+    {
+      "id": "content-quality-main",
+      "file": ".github/workflows/content-quality-main.yml",
+      "events": {
+        "push": [
+          ".github/workflows/content-quality.yml",
+          ".github/workflows/content-quality-main.yml",
+          ".github/workflows/pages.yml",
+          "CNAME",
+          "assets/**",
+          "config/workflow-trigger-policy.json",
+          "content/**",
+          "gb/**",
+          "package-lock.json",
+          "package.json",
+          "scripts/**",
+          "test/**"
+        ]
+      }
+    },
+    {
+      "id": "codeql",
+      "file": ".github/workflows/codeql.yml",
+      "events": {
+        "push": [
+          "assets/js/**",
+          "config/workflow-trigger-policy.json",
+          "gb/**",
+          "scripts/**",
+          "test/**",
+          "package.json",
+          "package-lock.json",
+          ".github/workflows/codeql.yml"
+        ],
+        "pull_request": [
+          "assets/js/**",
+          "config/workflow-trigger-policy.json",
+          "gb/**",
+          "scripts/**",
+          "test/**",
+          "package.json",
+          "package-lock.json",
+          ".github/workflows/codeql.yml"
+        ]
+      }
+    },
+    {
+      "id": "game-boy-rom",
+      "file": ".github/workflows/game-boy-rom.yml",
+      "events": {
+        "push": [
+          ".github/workflows/game-boy-rom.yml",
+          "config/workflow-trigger-policy.json",
+          "content/posts/**",
+          "gb/**",
+          "scripts/build-gb-rom.sh",
+          "scripts/build-gb.mjs",
+          "scripts/post-metadata.mjs"
+        ],
+        "pull_request": [
+          ".github/workflows/game-boy-rom.yml",
+          "config/workflow-trigger-policy.json",
+          "content/posts/**",
+          "gb/**",
+          "scripts/build-gb-rom.sh",
+          "scripts/build-gb.mjs",
+          "scripts/post-metadata.mjs"
+        ]
+      }
+    },
+    {
+      "id": "pages",
+      "file": ".github/workflows/pages.yml",
+      "notes": [
+        "workflow_run driven; documented here for policy context but not path-checked"
+      ]
+    }
+  ],
+  "symmetryRules": [
+    {
+      "name": "site-affecting workflow edits stay symmetrical across PR and main validation",
+      "left": ["content-quality", "pull_request"],
+      "right": ["content-quality-main", "push"],
+      "paths": [
+        ".github/workflows/content-quality.yml",
+        ".github/workflows/content-quality-main.yml",
+        ".github/workflows/pages.yml",
+        "CNAME",
+        "assets/**",
+        "config/workflow-trigger-policy.json",
+        "content/**",
+        "gb/**",
+        "package-lock.json",
+        "package.json",
+        "scripts/**",
+        "test/**"
+      ]
+    },
+    {
+      "name": "codeql trigger coverage stays symmetrical across PR and main",
+      "left": ["codeql", "pull_request"],
+      "right": ["codeql", "push"],
+      "paths": [
+        "assets/js/**",
+        "config/workflow-trigger-policy.json",
+        "gb/**",
+        "scripts/**",
+        "test/**",
+        "package.json",
+        "package-lock.json",
+        ".github/workflows/codeql.yml"
+      ]
+    },
+    {
+      "name": "game-boy-rom trigger coverage stays symmetrical across PR and main",
+      "left": ["game-boy-rom", "pull_request"],
+      "right": ["game-boy-rom", "push"],
+      "paths": [
+        ".github/workflows/game-boy-rom.yml",
+        "config/workflow-trigger-policy.json",
+        "content/posts/**",
+        "gb/**",
+        "scripts/build-gb-rom.sh",
+        "scripts/build-gb.mjs",
+        "scripts/post-metadata.mjs"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "node --test",
     "check:frontmatter": "node scripts/check-frontmatter.mjs",
     "check:internal-links": "node scripts/check-internal-links.mjs",
-    "check:content-quality": "npm test && npm run check:frontmatter && npm run build:gb:data && npm run build && npm run check:internal-links",
+    "check:workflow-trigger-policy": "node scripts/check-workflow-trigger-policy.mjs",
+    "check:content-quality": "npm run check:workflow-trigger-policy && npm test && npm run check:frontmatter && npm run build:gb:data && npm run build && npm run check:internal-links",
     "build:gb:data": "node scripts/build-gb.mjs",
     "build:gb": "bash scripts/build-gb-rom.sh"
   },

--- a/scripts/check-workflow-trigger-policy.mjs
+++ b/scripts/check-workflow-trigger-policy.mjs
@@ -47,7 +47,6 @@ function extractEventPaths(content, eventName) {
   }
 
   const match = pathLine.line.match(/^    paths:\s*(?:&([A-Za-z0-9_-]+)|\*([A-Za-z0-9_-]+))?\s*$/);
-  const definedAnchor = match?.[1] ?? null;
   const referencedAnchor = match?.[2] ?? null;
 
   if (referencedAnchor) {

--- a/scripts/check-workflow-trigger-policy.mjs
+++ b/scripts/check-workflow-trigger-policy.mjs
@@ -1,0 +1,161 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const matrix = JSON.parse(
+  readFileSync(path.join(repoRoot, 'config/workflow-trigger-policy.json'), 'utf8'),
+);
+
+function getIndentedBlock(lines, startIndex, indentLevel) {
+  const block = [];
+
+  for (let i = startIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.trim()) {
+      continue;
+    }
+
+    const indent = line.match(/^ */)[0].length;
+    if (indent <= indentLevel) {
+      break;
+    }
+
+    block.push({ line, indent, index: i });
+  }
+
+  return block;
+}
+
+function extractEventPaths(content, eventName) {
+  const lines = content.split(/\r?\n/);
+  const eventHeader = new RegExp(`^  ${eventName}:\\s*(?:&[A-Za-z0-9_-]+)?\\s*$`);
+  const eventIndex = lines.findIndex((line) => eventHeader.test(line));
+
+  if (eventIndex === -1) {
+    return null;
+  }
+
+  const eventBlock = getIndentedBlock(lines, eventIndex, 2);
+  const pathLine = eventBlock.find(({ line }) => /^    paths:\s*(?:&([A-Za-z0-9_-]+)|\*([A-Za-z0-9_-]+))?\s*$/.test(line));
+
+  if (!pathLine) {
+    return [];
+  }
+
+  const match = pathLine.line.match(/^    paths:\s*(?:&([A-Za-z0-9_-]+)|\*([A-Za-z0-9_-]+))?\s*$/);
+  const definedAnchor = match?.[1] ?? null;
+  const referencedAnchor = match?.[2] ?? null;
+
+  if (referencedAnchor) {
+    const anchorLineIndex = lines.findIndex((line) => new RegExp(`^    paths:\\s*&${referencedAnchor}\\s*$`).test(line));
+
+    if (anchorLineIndex === -1) {
+      throw new Error(`Could not resolve YAML anchor *${referencedAnchor} in workflow file.`);
+    }
+
+    return extractPathsList(lines, anchorLineIndex);
+  }
+
+  return extractPathsList(lines, pathLine.index);
+}
+
+function extractPathsList(lines, pathsIndex) {
+  const pathEntries = [];
+
+  for (let i = pathsIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.trim()) {
+      continue;
+    }
+
+    const indent = line.match(/^ */)[0].length;
+    if (indent <= 4) {
+      break;
+    }
+
+    const match = line.match(/^      - '([^']+)'\s*$/);
+    if (!match) {
+      throw new Error(`Unsupported paths entry format: ${line}`);
+    }
+
+    pathEntries.push(match[1]);
+  }
+
+  return pathEntries;
+}
+
+function compareList(name, actual, expected, errors) {
+  const actualJoined = actual.join('\n');
+  const expectedJoined = expected.join('\n');
+
+  if (actualJoined !== expectedJoined) {
+    errors.push([
+      `${name} paths drifted.`,
+      'Expected:',
+      ...expected.map((entry) => `  - ${entry}`),
+      'Actual:',
+      ...actual.map((entry) => `  - ${entry}`),
+    ].join('\n'));
+  }
+}
+
+const errors = [];
+
+for (const workflow of matrix.workflows) {
+  const workflowPath = path.join(repoRoot, workflow.file);
+  const content = readFileSync(workflowPath, 'utf8');
+
+  for (const [eventName, expectedPaths] of Object.entries(workflow.events ?? {})) {
+    const actualPaths = extractEventPaths(content, eventName);
+
+    if (actualPaths === null) {
+      errors.push(`${workflow.file} is missing expected event '${eventName}'.`);
+      continue;
+    }
+
+    compareList(`${workflow.file} (${eventName})`, actualPaths, expectedPaths, errors);
+  }
+}
+
+for (const rule of matrix.symmetryRules ?? []) {
+  const [leftWorkflow, leftEvent] = rule.left;
+  const [rightWorkflow, rightEvent] = rule.right;
+  const left = matrix.workflows.find((workflow) => workflow.id === leftWorkflow);
+  const right = matrix.workflows.find((workflow) => workflow.id === rightWorkflow);
+
+  if (!left || !right) {
+    errors.push(`Invalid symmetry rule '${rule.name}': unknown workflow id.`);
+    continue;
+  }
+
+  const leftPaths = left.events?.[leftEvent] ?? [];
+  const rightPaths = right.events?.[rightEvent] ?? [];
+
+  const leftSubset = rule.paths;
+  const leftMissing = leftSubset.filter((entry) => !leftPaths.includes(entry));
+  const rightMissing = leftSubset.filter((entry) => !rightPaths.includes(entry));
+
+  if (leftMissing.length || rightMissing.length) {
+    errors.push([
+      `Symmetry rule failed: ${rule.name}`,
+      `Expected both ${left.file} (${leftEvent}) and ${right.file} (${rightEvent}) to include:`,
+      ...leftSubset.map((entry) => `  - ${entry}`),
+      ...(leftMissing.length ? ['Missing on left:', ...leftMissing.map((entry) => `  - ${entry}`)] : []),
+      ...(rightMissing.length ? ['Missing on right:', ...rightMissing.map((entry) => `  - ${entry}`)] : []),
+    ].join('\n'));
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Workflow trigger policy check failed.\n');
+  for (const error of errors) {
+    console.error(`- ${error}\n`);
+  }
+  process.exit(1);
+}
+
+console.log('Workflow trigger policy check passed.');


### PR DESCRIPTION
## Summary
- add a checked-in workflow trigger policy matrix for content-quality, content-quality-main, codeql, and game-boy-rom
- add a repo script that compares the declared matrix against the actual workflow `paths` filters, including the ROM workflow's shared YAML anchor
- run that check in content-quality, codeql, and game-boy-rom, and trigger those workflows when the policy file changes

## Testing
- npm ci
- npm run check:content-quality

Closes #383.
