### PR TITLE
ci: make manual Pages deploys main-only

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,14 +18,16 @@ concurrency:
 jobs:
   build:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event_name == 'workflow_dispatch' && github.ref_name == 'main') ||
+      (github.event_name != 'workflow_dispatch' && github.event.workflow_run.conclusion == 'success')
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: main
 
       - name: Setup Node
         if: github.event_name == 'workflow_dispatch'
@@ -61,8 +63,8 @@ jobs:
 
   deploy:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event_name == 'workflow_dispatch' && github.ref_name == 'main') ||
+      (github.event_name != 'workflow_dispatch' && github.event.workflow_run.conclusion == 'success')
     timeout-minutes: 10
     permissions:
       pages: write


### PR DESCRIPTION
Closes #389

## Summary
- only allow manual `workflow_dispatch` deploy jobs to run from `main`
- explicitly checkout `main` for manual deploys
- keep the validated artifact path for normal post-merge deploys