### PR TITLE
ci: refresh action pins before node20 switch

### DIFF
--- a/.github/workflows/content-quality-main.yml
+++ b/.github/workflows/content-quality-main.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm run check:content-quality
 
       - name: Upload validated site artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: validated-site-dist
           path: dist

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Decide whether workflow_run deploy is still current
         if: github.event_name == 'workflow_run'
         id: guard-workflow-run
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { owner, repo } = context.repo;


### PR DESCRIPTION
## Summary
- refresh the `actions/github-script` pin in `pages.yml` from v8 to v9
- refresh the validated-site `actions/upload-artifact` pin in `content-quality-main.yml` from v4.6.2 to v7
- keep the existing deploy guard and artifact flow unchanged while removing the action revisions that started warning about the upcoming Node 20 deprecation switch

Closes #393.

## Testing
- workflow-only change
