### PR TITLE
content: refresh curated reading path

### DIFF
--- a/content/site.json
+++ b/content/site.json
@@ -27,9 +27,9 @@
         "note": "Technical / operational safety"
       },
       {
-        "title": "How maintainers should evaluate novelty ports",
-        "href": "/posts/2026-03-30-how-maintainers-should-evaluate-novelty-ports.html",
-        "note": "Technical / project strategy"
+        "title": "Your security scanner should follow your executable surface",
+        "href": "/posts/2026-06-09-your-security-scanner-should-follow-your-executable-surface.html",
+        "note": "Security / maintainer operations"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- replace the older novelty-ports slot in curated reading
- surface the newer executable-surface security-scanner post on the homepage

## Why
The curated path should point first-time readers at the strongest current maintainer/security material, not just older archive picks.