### PR TITLE
ci: run content-quality on workflow-only PRs

### DIFF
--- a/.github/workflows/content-quality-main.yml
+++ b/.github/workflows/content-quality-main.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/codeql.yml'
       - '.github/workflows/content-quality.yml'
       - '.github/workflows/content-quality-main.yml'
+      - '.github/workflows/dependabot-auto-merge.yml'
       - '.github/workflows/game-boy-rom.yml'
       - '.github/workflows/pages.yml'
       - 'CNAME'

--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -4,8 +4,10 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - '.github/workflows/codeql.yml'
       - '.github/workflows/content-quality.yml'
       - '.github/workflows/content-quality-main.yml'
+      - '.github/workflows/dependabot-auto-merge.yml'
       - '.github/workflows/game-boy-rom.yml'
       - '.github/workflows/pages.yml'
       - 'CNAME'

--- a/config/workflow-trigger-policy.json
+++ b/config/workflow-trigger-policy.json
@@ -5,8 +5,10 @@
       "file": ".github/workflows/content-quality.yml",
       "events": {
         "pull_request": [
+          ".github/workflows/codeql.yml",
           ".github/workflows/content-quality.yml",
           ".github/workflows/content-quality-main.yml",
+          ".github/workflows/dependabot-auto-merge.yml",
           ".github/workflows/game-boy-rom.yml",
           ".github/workflows/pages.yml",
           "CNAME",
@@ -26,8 +28,10 @@
       "file": ".github/workflows/content-quality-main.yml",
       "events": {
         "push": [
+          ".github/workflows/codeql.yml",
           ".github/workflows/content-quality.yml",
           ".github/workflows/content-quality-main.yml",
+          ".github/workflows/dependabot-auto-merge.yml",
           ".github/workflows/game-boy-rom.yml",
           ".github/workflows/pages.yml",
           "CNAME",
@@ -106,8 +110,10 @@
       "left": ["content-quality", "pull_request"],
       "right": ["content-quality-main", "push"],
       "paths": [
+        ".github/workflows/codeql.yml",
         ".github/workflows/content-quality.yml",
         ".github/workflows/content-quality-main.yml",
+        ".github/workflows/dependabot-auto-merge.yml",
         ".github/workflows/game-boy-rom.yml",
         ".github/workflows/pages.yml",
         "CNAME",


### PR DESCRIPTION
## Summary
- run `Content quality` when `.github/workflows/codeql.yml` changes
- run `Content quality` when `.github/workflows/dependabot-auto-merge.yml` changes
- keep the trigger policy mirror in sync

## Why
PRs #400 and #401 are safe workflow-only dependabot bumps, but branch protection still expects `validate-content`. Without these paths, those PRs can get stuck with the required check missing entirely.

## Testing
- `npm run check:content-quality`
