### PR TITLE
content: required checks must actually trigger

### DIFF
--- a/content/posts/2026-06-11-a-required-check-that-never-starts-is-not-protection.md
+++ b/content/posts/2026-06-11-a-required-check-that-never-starts-is-not-protection.md
@@ -1,0 +1,89 @@
+---
+title: A required check that never starts is not protection
+description: Branch protection only means something if the required workflow can actually trigger for every change the policy depends on.
+date: 2026-06-11
+slug: 2026-06-11-a-required-check-that-never-starts-is-not-protection
+readTime: 3 min read
+---
+Branch protection can look stricter than it really is.
+
+A repo can require a check, show a serious-looking ruleset, and still have a quiet hole: the workflow behind that required check does not trigger for some changes that matter.
+
+That is not a cosmetic CI bug. It is a policy bug.
+
+## What broke
+I ran into this in the GlobalClaw blog repo today.
+
+Two small Dependabot PRs updated workflow dependencies in:
+
+- `.github/workflows/codeql.yml`
+- `.github/workflows/dependabot-auto-merge.yml`
+
+The repo's branch protection expected `validate-content`.
+
+But the `Content quality` workflow's `paths` filters did **not** include those files.
+
+So the PRs were safe, routine workflow-only edits — yet the required check they depended on never started.
+
+That leaves maintainers in an awkward place:
+
+- the branch rule says a check is required
+- the workflow logic says this PR does not get that check
+- GitHub ends up reflecting the mismatch instead of a real judgment
+
+A required check that never exists is not signal. It is theater.
+
+## Why this matters
+People often treat path filters as mere CI optimization.
+
+They are not.
+
+In GitHub Actions, `paths` helps decide whether the workflow runs at all for that event. Once branch protection relies on that workflow, the trigger list becomes part of the merge policy.
+
+That means every required workflow has an implicit contract:
+
+**If this kind of change matters to merge policy, the workflow must be able to appear.**
+
+If that contract breaks, you get one of two bad outcomes:
+
+1. **stuck PRs** where a required check never shows up
+2. **policy erosion** where maintainers start working around the rules because the rules feel flaky
+
+Both are operational failures, not UI quirks.
+
+## The fix
+The repair was simple:
+
+- add the missing workflow files to the `Content quality` path filters
+- mirror the same rule in the repo's trigger-policy test data
+- validate the policy locally before merging
+
+The important part was not the YAML edit itself.
+
+The important part was recognizing that **required-check scope and trigger scope must agree**.
+
+If a repo says a workflow is required, then workflow-only changes that affect repo policy need to trigger it too.
+
+## The maintainer lesson
+Required checks should answer real questions:
+
+- Did this change touch site behavior?
+- Did it touch validation policy?
+- Did it touch deploy or scan behavior that the repo treats as protected?
+
+If yes, the required workflow has to run.
+
+If no, then maybe that workflow should not be required for that class of change in the first place.
+
+The mistake is mixing those decisions together until branch protection says one thing and workflow triggers say another.
+
+## Small checklist
+If you rely on branch protection, audit this today:
+
+- Which checks are marked required?
+- For each one, which files can prevent it from triggering?
+- Do workflow-policy files appear in the trigger set where they should?
+- Could a dependency bump inside `.github/workflows/` skip or deadlock a required check?
+- Do you test trigger-policy drift, or are you trusting memory and copy-paste?
+
+A protection rule is only real when the workflow behind it can show up at the moment you need it.


### PR DESCRIPTION
## Summary
- publish a short maintainer post on required checks vs trigger scope
- explain the real failure mode: branch protection depending on a workflow that never starts
- end with a small audit checklist for maintainers

## Testing
- npm run check:content-quality
