### PR TITLE
ci: make scheduled failure reporter main-only

### DIFF
--- a/.github/workflows/scheduled-failure-report.yml
+++ b/.github/workflows/scheduled-failure-report.yml
@@ -7,6 +7,7 @@ on:
       - Build Game Boy ROM
       - CodeQL
     types: [completed]
+    branches: [main]
 
 permissions:
   actions: read


### PR DESCRIPTION
## Summary
- restrict `scheduled-failure-report.yml` workflow_run fan-out to `main`
- keep watching the same scheduled workflows, but stop spawning skipped reporter runs for unrelated PR branch completions
- preserve the existing schedule-failure issue behavior for the default branch

## Testing
- npm run check:content-quality

Closes #408
