### PR TITLE
ci: ignore in-progress scheduled runs when polling failures

### DIFF
--- a/.github/workflows/scheduled-failure-report.yml
+++ b/.github/workflows/scheduled-failure-report.yml
@@ -68,10 +68,10 @@ jobs:
                 per_page: 100
               });
 
-              const latest = runs.workflow_runs.find((run) => run.name === workflowName);
+              const latest = runs.workflow_runs.find((run) => run.name === workflowName && run.status === 'completed');
 
               if (!latest) {
-                core.info(`No scheduled runs found yet for ${workflowName}`);
+                core.info(`No completed scheduled runs found yet for ${workflowName}`);
                 continue;
               }
 


### PR DESCRIPTION
## Summary
- ignore queued/in-progress scheduled runs in the scheduled failure poller
- only let completed scheduled runs drive the rolling issue open/close state
- avoid false positive failure issues while the latest scheduled run is still executing

## Testing
- npm run check:content-quality

Closes #412.
