### PR TITLE
ci: fix fetch-metadata pin comment

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v2.4.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- correct the inline version comment for the pinned dependabot/fetch-metadata action
- keep the pinned SHA unchanged; this is documentation/audit-trail cleanup only

## Why
The workflow is already pinned to the v3.1.0 commit, but the inline comment still said v2.4.0 after #400. That makes quick supply-chain reviews noisier than they need to be.