### PR TITLE
fix: repair watchdog workflow expression syntax

### DIFF
--- a/.github/workflows/scheduled-failure-watchdog.yml
+++ b/.github/workflows/scheduled-failure-watchdog.yml
@@ -16,10 +16,10 @@ concurrency:
 jobs:
   watchdog:
     if: >-
-      ${
+      ${{
         github.event.workflow_run.event == 'schedule' &&
         github.event.workflow_run.head_branch == 'main'
-      }
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Open, refresh, or close the reporter failure issue


### PR DESCRIPTION
## Summary
- fix the malformed job-level expression in the scheduled failure watchdog workflow
- restore the intended `schedule` + `main` guard so the watchdog can actually run

## Testing
- npm run check:content-quality

Closes #419.
