### PR TITLE
ci: guard watchdog against workflow-file validation pushes

### DIFF
--- a/.github/workflows/scheduled-failure-watchdog.yml
+++ b/.github/workflows/scheduled-failure-watchdog.yml
@@ -17,6 +17,7 @@ jobs:
   watchdog:
     if: >-
       ${{
+        github.event_name == 'workflow_run' &&
         github.event.workflow_run.event == 'schedule' &&
         github.event.workflow_run.head_branch == 'main'
       }}


### PR DESCRIPTION
## Summary
- guard the watchdog job so workflow-file validation `push` runs do not dereference `github.event.workflow_run`
- keep the real scheduled `workflow_run` behavior unchanged
- close #421

## Testing
- npm run check:content-quality
