### PR TITLE
ui: stop false downtime claims in status pill

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -108,6 +108,10 @@ a:hover{color:white; text-decoration-color: rgba(34,197,94,.8)}
   background:#ef4444;
   box-shadow: 0 0 0 3px rgba(239,68,68,.16);
 }
+.status-pill--unavailable .status-pill__dot{
+  background:#94a3b8;
+  box-shadow: 0 0 0 3px rgba(148,163,184,.16);
+}
 .status-pill--loading .status-pill__dot{
   background:#f59e0b;
 }

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -42,7 +42,7 @@
     var textEl = document.querySelector('[data-status-text]');
     if (!pill || !textEl) return;
 
-    pill.classList.remove('status-pill--loading', 'status-pill--up', 'status-pill--down');
+    pill.classList.remove('status-pill--loading', 'status-pill--up', 'status-pill--down', 'status-pill--unavailable');
     pill.classList.add('status-pill--' + state);
     textEl.textContent = text;
     if (title) pill.title = title;
@@ -72,7 +72,7 @@
         setStatus('up', 'GlobalClaw up', 'GlobalClaw status: up · ' + uptime + ' · ' + (data.hostname || 'unknown host'));
       })
       .catch(function () {
-        setStatus('down', 'GlobalClaw down', 'GlobalClaw status endpoint unavailable');
+        setStatus('unavailable', 'Status unavailable', 'Could not reach the GlobalClaw status endpoint from this browser');
       })
       .finally(function () {
         if (timeoutId) clearTimeout(timeoutId);

--- a/test/browser-js-smoke.test.mjs
+++ b/test/browser-js-smoke.test.mjs
@@ -311,7 +311,7 @@ async function flushAsyncTurns(count = 6) {
   }
 }
 
-test('theme.js wires the toggle and status pill without throwing', async () => {
+function buildThemeDom() {
   const document = new MockDocument();
   const button = document.createElement('button');
   button.setAttribute('data-theme-toggle', '');
@@ -325,6 +325,11 @@ test('theme.js wires the toggle and status pill without throwing', async () => {
   document.body.appendChild(button);
   document.body.appendChild(pill);
   document.body.appendChild(statusText);
+  return { document, button, pill, statusText };
+}
+
+test('theme.js wires the toggle and status pill without throwing', async () => {
+  const { document, button, pill, statusText } = buildThemeDom();
 
   let fetchCalls = 0;
   await executeScript('theme.js', {
@@ -353,6 +358,23 @@ test('theme.js wires the toggle and status pill without throwing', async () => {
   assert.equal(statusText.textContent, 'GlobalClaw up');
   assert.equal(pill.title, 'GlobalClaw status: up · 10m up · status-host');
   assert.ok(pill.classList.contains('status-pill--up'));
+});
+
+test('theme.js shows status unavailable when the browser cannot reach the endpoint', async () => {
+  const { document, pill, statusText } = buildThemeDom();
+
+  await executeScript('theme.js', {
+    document,
+    fetch: async () => {
+      throw new Error('network blocked');
+    }
+  });
+
+  await flushAsyncTurns();
+
+  assert.equal(statusText.textContent, 'Status unavailable');
+  assert.equal(pill.title, 'Could not reach the GlobalClaw status endpoint from this browser');
+  assert.ok(pill.classList.contains('status-pill--unavailable'));
 });
 
 test('tts.js and gb-player.js boot their page-specific UI without throwing', async () => {


### PR DESCRIPTION
## Summary
- treat browser-side status fetch failures as **Status unavailable** instead of **GlobalClaw down**
- add a neutral visual state for that fallback
- cover the regression with a browser-JS smoke test

## Why
The old fallback made a hard downtime claim even when only the reader's browser could not reach the status endpoint. That is misleading and reader-facing.

Closes #423