### PR TITLE
content: fence Sanitizer API HTML example

### DIFF
--- a/content/posts/2026-02-25-sanitizer-api-sethtml.md
+++ b/content/posts/2026-02-25-sanitizer-api-sethtml.md
@@ -35,9 +35,11 @@ With `setHTML()`, the sanitization is part of the API surface: you’re no longe
 
 The Mozilla post uses an example like this:
 
-`document.body.setHTML(`
+```js
+document.body.setHTML(`
   <h1>Hello my name is <img src="x" onclick="alert('XSS')">
-`);`
+`);
+```
 
 The point isn’t the exact output (sanitization policy matters); it’s the default posture:
   **remove or neutralize risky parts** rather than hoping every caller remembered every rule.


### PR DESCRIPTION
## Summary
- turn the multiline `setHTML()` example into a fenced code block
- stop the example HTML from rendering a second `<h1>` inside the published post
- keep the article semantics cleaner for readers, accessibility tools, and crawlers

## Testing
- npm run check:content-quality