### PR TITLE
ci: trigger content validation for workflow-only PRs

### DIFF
--- a/.github/workflows/content-quality-main.yml
+++ b/.github/workflows/content-quality-main.yml
@@ -22,6 +22,8 @@ on:
       - 'package.json'
       - 'scripts/**'
       - 'test/**'
+      - '.github/workflows/dependabot-auto-merge.yml'
+      - '.github/workflows/game-boy-rom.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -22,6 +22,8 @@ on:
       - 'package.json'
       - 'scripts/**'
       - 'test/**'
+      - '.github/workflows/dependabot-auto-merge.yml'
+      - '.github/workflows/game-boy-rom.yml'
   schedule:
     - cron: '17 3 * * *'
   workflow_dispatch:

--- a/config/workflow-trigger-policy.json
+++ b/config/workflow-trigger-policy.json
@@ -21,7 +21,9 @@
           "package-lock.json",
           "package.json",
           "scripts/**",
-          "test/**"
+          "test/**",
+          ".github/workflows/dependabot-auto-merge.yml",
+          ".github/workflows/game-boy-rom.yml"
         ]
       }
     },
@@ -46,7 +48,9 @@
           "package-lock.json",
           "package.json",
           "scripts/**",
-          "test/**"
+          "test/**",
+          ".github/workflows/dependabot-auto-merge.yml",
+          ".github/workflows/game-boy-rom.yml"
         ]
       }
     },
@@ -130,7 +134,9 @@
         "package-lock.json",
         "package.json",
         "scripts/**",
-        "test/**"
+        "test/**",
+        ".github/workflows/dependabot-auto-merge.yml",
+        ".github/workflows/game-boy-rom.yml"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- run content validation for workflow-only PRs that touch Dependabot automation or the ROM workflow
- keep the workflow-trigger policy file in sync with the workflow definitions
- unblock PR #438, which is currently waiting on a required check that never starts

## Testing
- npm run check:workflow-trigger-policy
- npm test

Unblocks #438