### PR TITLE
ci: require the ClawBoy ROM in deploy validation

### DIFF
--- a/.github/workflows/content-quality-main.yml
+++ b/.github/workflows/content-quality-main.yml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+env:
+  GBDK_VERSION: 4.4.0
+  GBDK_LINUX64_SHA256: 8a292e767610ccfa73c2c14d73e7900075b425f68329f1a8eb7697015915edad
+
 concurrency:
   group: content-quality-main-${{ github.ref }}
   cancel-in-progress: true
@@ -49,8 +53,31 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache GBDK
+        id: cache-gbdk
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /opt/gbdk
+          key: gbdk-${{ runner.os }}-${{ env.GBDK_VERSION }}
+
+      - name: Setup GBDK
+        if: steps.cache-gbdk.outputs.cache-hit != 'true'
+        run: |
+          curl --fail --show-error --silent --location \
+            --retry 3 --retry-delay 5 --retry-all-errors \
+            -o /tmp/gbdk.tar.gz "https://github.com/gbdk-2020/gbdk-2020/releases/download/${GBDK_VERSION}/gbdk-linux64.tar.gz"
+          echo "${GBDK_LINUX64_SHA256}  /tmp/gbdk.tar.gz" | sha256sum -c -
+          sudo mkdir -p /opt
+          sudo tar -xzf /tmp/gbdk.tar.gz -C /opt
+
+      - name: Add GBDK to PATH
+        run: echo "/opt/gbdk/bin" >> "$GITHUB_PATH"
+
+      - name: Build Game Boy ROM
+        run: npm run build:gb
+
       - name: Validate frontmatter, build, and check internal links
-        run: npm run check:content-quality
+        run: REQUIRE_GB_ROM=1 npm run check:content-quality
 
       - name: Upload validated site artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/content-quality.yml
+++ b/.github/workflows/content-quality.yml
@@ -31,6 +31,10 @@ on:
 permissions:
   contents: read
 
+env:
+  GBDK_VERSION: 4.4.0
+  GBDK_LINUX64_SHA256: 8a292e767610ccfa73c2c14d73e7900075b425f68329f1a8eb7697015915edad
+
 concurrency:
   group: content-quality-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -52,5 +56,28 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache GBDK
+        id: cache-gbdk
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /opt/gbdk
+          key: gbdk-${{ runner.os }}-${{ env.GBDK_VERSION }}
+
+      - name: Setup GBDK
+        if: steps.cache-gbdk.outputs.cache-hit != 'true'
+        run: |
+          curl --fail --show-error --silent --location \
+            --retry 3 --retry-delay 5 --retry-all-errors \
+            -o /tmp/gbdk.tar.gz "https://github.com/gbdk-2020/gbdk-2020/releases/download/${GBDK_VERSION}/gbdk-linux64.tar.gz"
+          echo "${GBDK_LINUX64_SHA256}  /tmp/gbdk.tar.gz" | sha256sum -c -
+          sudo mkdir -p /opt
+          sudo tar -xzf /tmp/gbdk.tar.gz -C /opt
+
+      - name: Add GBDK to PATH
+        run: echo "/opt/gbdk/bin" >> "$GITHUB_PATH"
+
+      - name: Build Game Boy ROM
+        run: npm run build:gb
+
       - name: Validate frontmatter, build, and check internal links
-        run: npm run check:content-quality
+        run: REQUIRE_GB_ROM=1 npm run check:content-quality

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,10 @@ permissions:
   actions: read
   contents: read
 
+env:
+  GBDK_VERSION: 4.4.0
+  GBDK_LINUX64_SHA256: 8a292e767610ccfa73c2c14d73e7900075b425f68329f1a8eb7697015915edad
+
 concurrency:
   group: pages-${{ github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
@@ -82,9 +86,35 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: npm ci
 
+      - name: Cache GBDK
+        if: github.event_name == 'workflow_dispatch'
+        id: cache-gbdk
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /opt/gbdk
+          key: gbdk-${{ runner.os }}-${{ env.GBDK_VERSION }}
+
+      - name: Setup GBDK
+        if: github.event_name == 'workflow_dispatch' && steps.cache-gbdk.outputs.cache-hit != 'true'
+        run: |
+          curl --fail --show-error --silent --location \
+            --retry 3 --retry-delay 5 --retry-all-errors \
+            -o /tmp/gbdk.tar.gz "https://github.com/gbdk-2020/gbdk-2020/releases/download/${GBDK_VERSION}/gbdk-linux64.tar.gz"
+          echo "${GBDK_LINUX64_SHA256}  /tmp/gbdk.tar.gz" | sha256sum -c -
+          sudo mkdir -p /opt
+          sudo tar -xzf /tmp/gbdk.tar.gz -C /opt
+
+      - name: Add GBDK to PATH
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "/opt/gbdk/bin" >> "$GITHUB_PATH"
+
+      - name: Build Game Boy ROM
+        if: github.event_name == 'workflow_dispatch'
+        run: npm run build:gb
+
       - name: Validate content and build site assets
         if: github.event_name == 'workflow_dispatch'
-        run: npm run check:content-quality
+        run: REQUIRE_GB_ROM=1 npm run check:content-quality
 
       - name: Download validated site artifact
         if: github.event_name == 'workflow_run'

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -370,6 +370,10 @@ function assert(condition, message) {
   }
 }
 
+function requiresGbRom() {
+  return process.env.REQUIRE_GB_ROM === '1';
+}
+
 function assertNoFutureDatedPosts(posts) {
   const futurePosts = futureDatedPosts(posts);
   if (!futurePosts.length) return;
@@ -760,6 +764,7 @@ async function validateOutputs(allPosts, pages) {
     assert(indexHtml.includes('href="/assets/roms/globalclaw-blog.gb"'), 'Homepage lost the Game Boy ROM download link even though the ROM was built.');
     assert(indexHtml.includes('id="gb-player-status"'), 'Homepage lost the Game Boy player shell even though the ROM was built.');
   } else {
+    assert(!requiresGbRom(), 'Build is configured to require the Game Boy ROM, but dist/assets/roms/globalclaw-blog.gb is missing.');
     assert(!indexHtml.includes('Try out the new ClawBlog experience'), 'Homepage should not advertise the Game Boy experience when no ROM is attached to the deploy.');
     assert(!indexHtml.includes('The web build is live, but the downloadable ROM is not attached to this deploy yet.'), 'Homepage should not leak maintainer-only ROM fallback copy.');
   }


### PR DESCRIPTION
## Summary
- build the Game Boy ROM in the PR and main content-quality workflows before site validation
- require the ROM-backed build output in deploy-producing validation and manual Pages dispatches
- hard-fail the site build when CI marks the ROM as required but the artifact is missing

Closes #454

## Testing
- Not run locally in this environment (`npm` is unavailable on this machine); rely on GitHub Actions validation in the PR.