### PR TITLE
feat: add Let the Crab Decide archive discovery

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -332,6 +332,69 @@ a:hover{color:white; text-decoration-color: rgba(34,197,94,.8)}
 .post-header h2{margin:0 0 6px}
 .post .backlink{margin-top: 18px}
 
+.crab-decide{
+  margin: 22px auto;
+  max-width: 760px;
+  padding: 24px;
+  color: #fff;
+  background: #b00068;
+  border: 4px solid #ffe600;
+  border-radius: 8px 28px 12px 32px;
+  box-shadow: 9px 9px 0 #00e5ff;
+  text-align: center;
+}
+.crab-decide__eyebrow{margin:0 0 6px; color:#ffe600; font-size:13px; font-weight:900; letter-spacing:.09em}
+.crab-decide h3{margin:0; color:#fff; font-size:clamp(28px, 7vw, 46px); line-height:1.05; text-transform:uppercase; text-shadow:3px 3px 0 #4a0030}
+.crab-decide > p:not(.crab-decide__eyebrow):not(.crab-decide__fallback){margin:12px auto; max-width:48ch; font-size:18px; font-weight:700}
+.crab-decide__button{
+  display:inline-block;
+  margin:8px 0 10px;
+  padding:13px 18px;
+  color:#24002d;
+  background:#00e5ff;
+  border:3px solid #fff;
+  border-radius:999px;
+  box-shadow:5px 5px 0 #4a0030;
+  font-weight:900;
+  letter-spacing:.04em;
+  text-decoration:none;
+}
+.crab-decide__button:hover,.crab-decide__button:focus-visible{color:#24002d; background:#fff; text-decoration:none; transform:translate(2px, 2px); box-shadow:3px 3px 0 #4a0030}
+.crab-decide__button:focus-visible,.crab-deliberation__skip:focus-visible{outline:3px solid #fff; outline-offset:4px}
+.crab-decide__button--deciding{pointer-events:none; opacity:.7}
+.crab-decide__fallback{margin:0; color:#fff; font-size:13px}
+
+.crab-deliberation{
+  position:fixed;
+  z-index:1000;
+  inset:0;
+  display:grid;
+  place-content:center;
+  gap:12px;
+  overflow:hidden;
+  padding:24px;
+  color:#fff;
+  background:#b00068;
+  text-align:center;
+}
+.crab-deliberation__crab{
+  display:block;
+  font-size:clamp(120px, 28vw, 360px);
+  line-height:1;
+  transform:scale(.2) rotate(-8deg);
+  transition:transform 5s cubic-bezier(.15,.8,.16,1);
+  filter:drop-shadow(10px 10px 0 #4a0030);
+}
+.crab-deliberation--active .crab-deliberation__crab{transform:scale(12) rotate(8deg)}
+.crab-deliberation__message{position:relative; margin:0; color:#ffe600; font-size:clamp(20px, 4vw, 32px); font-weight:900; text-shadow:3px 3px 0 #4a0030}
+.crab-deliberation__skip{position:relative; justify-self:center; padding:8px 12px; color:#24002d; background:#00e5ff; border:2px solid #fff; border-radius:999px; font:inherit; font-weight:800; cursor:pointer}
+.crab-deliberation--departing{pointer-events:none}
+
+@media (prefers-reduced-motion: reduce){
+  .crab-decide__button:hover,.crab-decide__button:focus-visible{transform:none}
+  .crab-deliberation__crab{transition:none}
+}
+
 .home-link{text-decoration:none}
 
 .site-footer{padding: 18px 0 28px; color: var(--muted); font-size: 13px}
@@ -399,6 +462,13 @@ a:hover{color:white; text-decoration-color: rgba(34,197,94,.8)}
 [data-theme="a11y-ry"] .logo{ color:#ffeb00; background: #b00000; }
 [data-theme="a11y-ry"] .button{ background: #b00000; border-color: #7a0000; color: #ffeb00; }
 [data-theme="a11y-ry"] .button.secondary{ background: rgba(255,255,255,.55); color: #b00000; border-color: rgba(176,0,0,.35); }
+[data-theme="a11y-ry"] .crab-decide{color:#b00000; background:#ffeb00; border-color:#b00000; box-shadow:none}
+[data-theme="a11y-ry"] .crab-decide__eyebrow{color:#b00000}
+[data-theme="a11y-ry"] .crab-decide h3{color:#b00000; text-shadow:none}
+[data-theme="a11y-ry"] .crab-decide__fallback{color:#7a0000}
+[data-theme="a11y-ry"] .crab-decide__button,[data-theme="a11y-ry"] .crab-deliberation__skip{color:#ffeb00; background:#b00000; border-color:#7a0000; box-shadow:none}
+[data-theme="a11y-ry"] .crab-deliberation{color:#ffeb00; background:#b00000}
+[data-theme="a11y-ry"] .crab-deliberation__message{color:#ffeb00; text-shadow:none}
 
 .tts-player{
   position: fixed;

--- a/assets/js/crab-decide.js
+++ b/assets/js/crab-decide.js
@@ -8,6 +8,9 @@
   }
 
   function navigate(target) {
+    // Only navigate to relative paths (post URLs are /posts/slug/).
+    // A relative URL starts with a slash and does not contain a protocol.
+    if (typeof target !== 'string' || target.charAt(0) !== '/') return;
     window.location.assign(target);
   }
 

--- a/assets/js/crab-decide.js
+++ b/assets/js/crab-decide.js
@@ -1,4 +1,5 @@
 (function () {
+  // 5 seconds of crab deliberation. This is a sacred amount of time.
   var DELIBERATION_MS = 5000;
 
   function reducedMotion() {

--- a/assets/js/crab-decide.js
+++ b/assets/js/crab-decide.js
@@ -8,10 +8,19 @@
   }
 
   function navigate(target) {
-    // Only navigate to relative paths (post URLs are /posts/slug/).
-    // A relative URL starts with a slash and does not contain a protocol.
-    if (typeof target !== 'string' || target.charAt(0) !== '/') return;
-    window.location.assign(target);
+    if (typeof target !== 'string' || !window.location || !window.location.origin || typeof window.URL !== 'function') return;
+
+    var url;
+    try {
+      url = new window.URL(target, window.location.origin);
+    } catch (error) {
+      return;
+    }
+
+    // Only navigate to same-origin published posts, and do it via the
+    // canonicalized path rather than the raw DOM-fed string.
+    if (url.origin !== window.location.origin || url.pathname.indexOf('/posts/') !== 0) return;
+    window.location.assign(url.pathname + url.search + url.hash);
   }
 
   function choose(choices) {

--- a/assets/js/crab-decide.js
+++ b/assets/js/crab-decide.js
@@ -1,0 +1,118 @@
+(function () {
+  var DELIBERATION_MS = 5000;
+
+  function reducedMotion() {
+    return typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+
+  function navigate(target) {
+    window.location.assign(target);
+  }
+
+  function choose(choices) {
+    return choices[Math.floor(Math.random() * choices.length)];
+  }
+
+  function createDeliberation(target) {
+    var overlay = document.createElement('div');
+    overlay.className = 'crab-deliberation';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-label', 'Crab deliberation');
+
+    var crab = document.createElement('span');
+    crab.className = 'crab-deliberation__crab';
+    crab.setAttribute('aria-hidden', 'true');
+    crab.textContent = '🦀';
+
+    var message = document.createElement('p');
+    message.className = 'crab-deliberation__message';
+    message.setAttribute('aria-live', 'polite');
+    message.textContent = 'The crab is deliberating…';
+
+    var skip = document.createElement('button');
+    skip.className = 'crab-deliberation__skip';
+    skip.type = 'button';
+    skip.setAttribute('data-crab-skip', '');
+    skip.textContent = 'Skip crab deliberation';
+
+    overlay.appendChild(crab);
+    overlay.appendChild(message);
+    overlay.appendChild(skip);
+    document.body.appendChild(overlay);
+
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(function () {
+        overlay.classList.add('crab-deliberation--active');
+      });
+    } else {
+      overlay.classList.add('crab-deliberation--active');
+    }
+
+    return { overlay: overlay, message: message, skip: skip };
+  }
+
+  var trigger = document.querySelector('[data-crab-decide]');
+  var choicesNode = document.querySelector('[data-crab-decide-posts]');
+  if (!trigger || !choicesNode) return;
+
+  var choices;
+  var deciding = false;
+  try {
+    choices = JSON.parse(choicesNode.textContent);
+  } catch (error) {
+    return;
+  }
+  if (!Array.isArray(choices) || choices.length === 0) return;
+
+  trigger.addEventListener('click', function (event) {
+    if (deciding) return;
+    if (event.button && event.button !== 0) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    if (typeof event.preventDefault === 'function') event.preventDefault();
+
+    var target = choose(choices);
+    deciding = true;
+    if (reducedMotion()) {
+      navigate(target);
+      return;
+    }
+
+    trigger.setAttribute('aria-disabled', 'true');
+    trigger.classList.add('crab-decide__button--deciding');
+
+    var ui = createDeliberation(target);
+    var complete = false;
+    var timers = [];
+
+    function schedule(callback, delay) {
+      timers.push(window.setTimeout(callback, delay));
+    }
+
+    function finish() {
+      if (complete) return;
+      complete = true;
+      for (var i = 0; i < timers.length; i += 1) window.clearTimeout(timers[i]);
+      ui.overlay.classList.add('crab-deliberation--departing');
+      navigate(target);
+    }
+
+    ui.skip.addEventListener('click', finish);
+    if (typeof ui.skip.focus === 'function') ui.skip.focus();
+
+    schedule(function () {
+      ui.message.textContent = 'Reviewing available shells…';
+    }, 1100);
+    schedule(function () {
+      ui.message.textContent = 'Ignoring your obvious choices…';
+    }, 2300);
+    schedule(function () {
+      ui.message.textContent = 'Consulting no one…';
+    }, 3500);
+    schedule(function () {
+      ui.message.textContent = 'Decision finalized.';
+    }, 4550);
+    schedule(finish, DELIBERATION_MS);
+  });
+})();

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -364,6 +364,21 @@ function curatedReadingSection() {
     </section>`;
 }
 
+function crabDecideSection(posts) {
+  const choices = posts.map((post) => post.outputPath);
+  const serializedChoices = JSON.stringify(choices).replace(/</g, '\\u003c');
+
+  return `
+    <section class="crab-decide" aria-labelledby="crab-decide-heading">
+      <p class="crab-decide__eyebrow">✨ ARCHIVE DISCOVERY PROTOCOL ✨</p>
+      <h3 id="crab-decide-heading">Let the crab decide</h3>
+      <p>The crab has reviewed your preferences and ignored them.</p>
+      <a class="crab-decide__button" data-crab-decide href="/posts/">🦀 LET THE CRAB DECIDE 🦀</a>
+      <p class="crab-decide__fallback">Without JavaScript, this opens the full post archive.</p>
+      <script type="application/json" data-crab-decide-posts>${serializedChoices}</script>
+    </section>`;
+}
+
 function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
@@ -578,6 +593,7 @@ async function buildIndexes(allPosts) {
     description: site.siteDescription,
     navCurrent: 'home',
     currentPath: '/index.html',
+    extraHead: '<script src="/assets/js/crab-decide.js?v=20260814a" defer></script>',
     body: `    <section class="hero">
       <h2>${escapeHtml(site.heroTitle)}</h2>
       <p>${escapeHtml(site.heroBody)}</p>
@@ -588,6 +604,8 @@ async function buildIndexes(allPosts) {
     </section>
 
 ${curatedReadingSection()}
+
+${crabDecideSection(allPosts)}
 
 ${gbSection}
 

--- a/test/browser-js-smoke.test.mjs
+++ b/test/browser-js-smoke.test.mjs
@@ -6,7 +6,7 @@ import vm from 'node:vm';
 
 const repoRoot = path.resolve(import.meta.dirname, '..');
 const jsDir = path.join(repoRoot, 'assets', 'js');
-const jsFiles = ['theme.js', 'tts.js', 'gb-player.js'];
+const jsFiles = ['theme.js', 'tts.js', 'gb-player.js', 'crab-decide.js'];
 
 class ClassList {
   constructor(initial = []) {
@@ -375,6 +375,60 @@ test('theme.js shows status unavailable when the browser cannot reach the endpoi
   assert.equal(statusText.textContent, 'Status unavailable');
   assert.equal(pill.title, 'Could not reach the GlobalClaw status endpoint from this browser');
   assert.ok(pill.classList.contains('status-pill--unavailable'));
+});
+
+function buildCrabDecideDom() {
+  const document = new MockDocument();
+  const trigger = document.createElement('a');
+  trigger.setAttribute('data-crab-decide', '');
+  trigger.setAttribute('href', '/posts/');
+  const choices = document.createElement('script');
+  choices.setAttribute('data-crab-decide-posts', '');
+  choices.textContent = JSON.stringify(['/posts/chosen-by-the-crab.html']);
+  document.body.appendChild(trigger);
+  document.body.appendChild(choices);
+  return { document, trigger };
+}
+
+test('crab-decide.js runs a skippable deliberation before navigating', async () => {
+  const { document, trigger } = buildCrabDecideDom();
+  const destinations = [];
+  const { timeouts } = await executeScript('crab-decide.js', {
+    document,
+    window: {
+      location: { assign(target) { destinations.push(target); } },
+      matchMedia() { return { matches: false }; }
+    }
+  });
+
+  trigger.click();
+  const overlay = document.querySelector('.crab-deliberation');
+  const skip = document.querySelector('[data-crab-skip]');
+  assert.ok(overlay, 'expected the crab deliberation overlay');
+  assert.ok(skip, 'expected a skip control');
+  assert.equal(destinations.length, 0);
+  assert.equal(timeouts.length, 5);
+
+  skip.click();
+  assert.deepEqual(destinations, ['/posts/chosen-by-the-crab.html']);
+  assert.ok(overlay.classList.contains('crab-deliberation--departing'));
+});
+
+test('crab-decide.js bypasses the ceremony for reduced motion', async () => {
+  const { document, trigger } = buildCrabDecideDom();
+  const destinations = [];
+  const { timeouts } = await executeScript('crab-decide.js', {
+    document,
+    window: {
+      location: { assign(target) { destinations.push(target); } },
+      matchMedia() { return { matches: true }; }
+    }
+  });
+
+  trigger.click();
+  assert.deepEqual(destinations, ['/posts/chosen-by-the-crab.html']);
+  assert.equal(document.querySelector('.crab-deliberation'), null);
+  assert.equal(timeouts.length, 0);
 });
 
 test('tts.js and gb-player.js boot their page-specific UI without throwing', async () => {

--- a/test/browser-js-smoke.test.mjs
+++ b/test/browser-js-smoke.test.mjs
@@ -293,6 +293,8 @@ async function executeScript(name, overrides = {}) {
   context.window.fetch = context.fetch;
   context.window.console = console;
   context.window.Promise = Promise;
+  context.URL = overrides.URL || URL;
+  context.window.URL = context.URL;
 
   vm.runInNewContext(source, context, { filename: name });
   return { context, document, localStorage, timeouts };
@@ -396,7 +398,10 @@ test('crab-decide.js runs a skippable deliberation before navigating', async () 
   const { timeouts } = await executeScript('crab-decide.js', {
     document,
     window: {
-      location: { assign(target) { destinations.push(target); } },
+      location: {
+        origin: 'https://globalclaw.se',
+        assign(target) { destinations.push(target); }
+      },
       matchMedia() { return { matches: false }; }
     }
   });
@@ -420,7 +425,10 @@ test('crab-decide.js bypasses the ceremony for reduced motion', async () => {
   const { timeouts } = await executeScript('crab-decide.js', {
     document,
     window: {
-      location: { assign(target) { destinations.push(target); } },
+      location: {
+        origin: 'https://globalclaw.se',
+        assign(target) { destinations.push(target); }
+      },
       matchMedia() { return { matches: true }; }
     }
   });
@@ -429,6 +437,33 @@ test('crab-decide.js bypasses the ceremony for reduced motion', async () => {
   assert.deepEqual(destinations, ['/posts/chosen-by-the-crab.html']);
   assert.equal(document.querySelector('.crab-deliberation'), null);
   assert.equal(timeouts.length, 0);
+});
+
+test('crab-decide.js ignores protocol-relative and off-path targets', async () => {
+  const document = new MockDocument();
+  const trigger = document.createElement('a');
+  trigger.setAttribute('data-crab-decide', '');
+  trigger.setAttribute('href', '/posts/');
+  const choices = document.createElement('script');
+  choices.setAttribute('data-crab-decide-posts', '');
+  choices.textContent = JSON.stringify(['//evil.example/posts/not-safe.html', '/about.html']);
+  document.body.appendChild(trigger);
+  document.body.appendChild(choices);
+
+  const destinations = [];
+  await executeScript('crab-decide.js', {
+    document,
+    window: {
+      location: {
+        origin: 'https://globalclaw.se',
+        assign(target) { destinations.push(target); }
+      },
+      matchMedia() { return { matches: true }; }
+    }
+  });
+
+  trigger.click();
+  assert.deepEqual(destinations, []);
 });
 
 test('tts.js and gb-player.js boot their page-specific UI without throwing', async () => {


### PR DESCRIPTION
## Summary

Adds **Let the Crab Decide**, a homepage archive-discovery control that sends readers to a randomly selected published post.

The homepage currently surfaces the newest posts, while the full archive contains 39 published entries. This gives readers an intentionally playful route into that wider catalog without adding a dependency, a backend, or a network request.

## Reader experience

- A visually distinct, high-contrast discovery card makes the control easy to find.
- The button remains a normal link to `/posts/` when JavaScript is unavailable.
- With JavaScript, it selects only a published GlobalClaw post.
- The selected destination is preceded by a five-second Crab Deliberation sequence.
- Readers can skip the sequence immediately.
- `prefers-reduced-motion: reduce` bypasses the sequence and navigates immediately.

## Implementation

- Adds one small browser script and no runtime dependencies.
- Uses the browser emoji crab rather than adding a mascot asset or image request.
- Keeps the control scoped to the homepage.
- Includes an explicit high-contrast theme presentation.

## Verification

- `npm test`
- `npm run check:content-quality`
- `node --check assets/js/crab-decide.js`
- Generated-homepage assertion confirming the panel, fallback, script, and local post choices.
